### PR TITLE
feat: add cart ui

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -94,5 +94,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { ReviewComponent }   from './features/auth/review/review.component';
 import { HomeComponent }     from './features/home/home.component';
 import { AdminComponent }    from './features/admin/admin.component';
 import { CatalogComponent } from './features/catalog/catalog.component';
+import { CartComponent } from './features/cart/cart.component';
 
 //ADMIN
 import { DashboardComponent } from './features/dashboard/dashboard.component';
@@ -35,6 +36,7 @@ export const routes: Routes = [
       { path: 'home',     component: HomeComponent },
       { path: 'admin',    component: AdminComponent,  canActivate: [adminGuard] },
       { path: 'catalogo', component: CatalogComponent },
+      { path: 'carrito', component: CartComponent },
       
       { path: 'dashboard', component: DashboardComponent },
       { path: 'inventario', component: InventoryListComponent /*, canActivate: [adminGuard]*/ },

--- a/src/app/features/cart/cart.component.html
+++ b/src/app/features/cart/cart.component.html
@@ -1,0 +1,195 @@
+<div class="max-w-6xl mx-auto px-4 py-6 space-y-6">
+  <header class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <p class="text-sm uppercase tracking-wide text-blue-600 font-semibold">Carrito de compras</p>
+      <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">Revisa los repuestos antes de pagar</h1>
+      <p class="text-sm text-gray-500 mt-1">
+        Gestiona cantidades, selecciona el método de envío y aplica cupones promocionales.
+      </p>
+    </div>
+    <div class="flex gap-3">
+      <button
+        mat-stroked-button
+        color="primary"
+        class="h-10"
+        (click)="clearCart()"
+        [disabled]="!cartItems.length"
+      >
+        <mat-icon class="!mr-2">delete_sweep</mat-icon>
+        Vaciar carrito
+      </button>
+      <a mat-stroked-button color="primary" routerLink="/catalogo" class="h-10 flex items-center gap-2">
+        <mat-icon>arrow_back</mat-icon>
+        Seguir comprando
+      </a>
+    </div>
+  </header>
+
+  <div class="grid gap-6 xl:grid-cols-[2fr_1fr]">
+    <section class="space-y-4" aria-label="Resumen de productos en el carrito">
+      <ng-container *ngIf="cartItems.length; else emptyState">
+        <mat-card *ngFor="let item of cartItems; trackBy: trackById" class="rounded-2xl shadow-sm border border-gray-100">
+          <div class="flex flex-col gap-4 sm:flex-row">
+            <div class="shrink-0 overflow-hidden rounded-xl sm:w-40 aspect-video">
+              <img [src]="item.image" [alt]="item.name" class="h-full w-full object-cover" />
+            </div>
+
+            <div class="flex flex-1 flex-col gap-3">
+              <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
+                <div>
+                  <h2 class="text-lg font-semibold text-gray-900">{{ item.name }}</h2>
+                  <p class="text-sm text-blue-600 font-medium">{{ item.brand }}</p>
+                  <p class="text-xs text-gray-500 mt-1">Compatibilidad: {{ item.compatibility }}</p>
+                </div>
+                <button mat-icon-button color="warn" class="-mr-2" (click)="removeItem(item.id)" aria-label="Eliminar">
+                  <mat-icon>close</mat-icon>
+                </button>
+              </div>
+
+              <mat-divider></mat-divider>
+
+              <div class="grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
+                <div class="flex items-center gap-3">
+                  <span class="text-xs uppercase tracking-wide text-gray-400">Cantidad</span>
+                  <div class="flex items-center rounded-full border border-gray-200 bg-gray-50">
+                    <button
+                      mat-icon-button
+                      type="button"
+                      (click)="updateQuantity(item.id, -1)"
+                      [disabled]="item.quantity <= 1"
+                      class="h-9 w-9"
+                      aria-label="Disminuir cantidad"
+                    >
+                      <mat-icon>remove</mat-icon>
+                    </button>
+                    <span class="w-10 text-center font-semibold">{{ item.quantity }}</span>
+                    <button
+                      mat-icon-button
+                      type="button"
+                      (click)="updateQuantity(item.id, 1)"
+                      [disabled]="item.quantity >= item.stock"
+                      class="h-9 w-9"
+                      aria-label="Aumentar cantidad"
+                    >
+                      <mat-icon>add</mat-icon>
+                    </button>
+                  </div>
+                  <span class="text-xs text-gray-500">{{ item.stock }} disponibles</span>
+                </div>
+
+                <div class="text-right">
+                  <p class="text-sm text-gray-500">Precio unitario</p>
+                  <p class="text-xl font-bold text-gray-900">
+                    {{ item.price | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}
+                  </p>
+                  <p class="text-xs text-gray-400 mt-1">
+                    Subtotal: {{ (item.price * item.quantity) | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </mat-card>
+      </ng-container>
+    </section>
+
+    <aside class="space-y-4" aria-label="Acciones del carrito">
+      <mat-card class="rounded-2xl shadow-sm border border-gray-100">
+        <mat-card-content class="space-y-4">
+          <div class="flex items-baseline justify-between">
+            <h2 class="text-lg font-semibold text-gray-900">Resumen</h2>
+            <span class="text-sm text-gray-500">{{ totalUnits }} {{ totalUnits === 1 ? 'producto' : 'productos' }}</span>
+          </div>
+
+          <div class="space-y-3">
+            <div class="flex items-center justify-between text-sm">
+              <span>Subtotal</span>
+              <span>{{ subtotal | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}</span>
+            </div>
+            <div class="flex items-center justify-between text-sm" [class.text-green-600]="discount > 0">
+              <span>Descuento</span>
+              <span>-{{ discount | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}</span>
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span>Envío</span>
+              <span>{{ shippingCost | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}</span>
+            </div>
+            <mat-divider></mat-divider>
+            <div class="flex items-center justify-between text-lg font-bold text-gray-900">
+              <span>Total</span>
+              <span>{{ total | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}</span>
+            </div>
+          </div>
+
+          <button
+            mat-flat-button
+            color="primary"
+            class="w-full h-12 text-base"
+            [disabled]="!cartItems.length"
+          >
+            Proceder al pago
+          </button>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card class="rounded-2xl shadow-sm border border-gray-100">
+        <mat-card-content class="space-y-4">
+          <h3 class="text-base font-semibold text-gray-900">Método de envío</h3>
+          <div class="grid gap-2">
+            <button
+              mat-stroked-button
+              *ngFor="let option of shippingOptions"
+              class="w-full justify-between !py-4"
+              [color]="option.id === selectedShipping.id ? 'primary' : undefined"
+              [class.bg-blue-50]="option.id === selectedShipping.id"
+              (click)="selectShipping(option)"
+              type="button"
+            >
+              <span class="text-left">
+                <span class="block font-medium">{{ option.label }}</span>
+                <span class="block text-xs text-gray-500">{{ option.description }}</span>
+              </span>
+              <span class="font-semibold">
+                {{ option.cost | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}
+              </span>
+            </button>
+          </div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card class="rounded-2xl shadow-sm border border-gray-100">
+        <mat-card-content class="space-y-3">
+          <h3 class="text-base font-semibold text-gray-900">Cupón de descuento</h3>
+          <mat-form-field appearance="outline" class="w-full">
+            <mat-label>Código promocional</mat-label>
+            <input matInput [(ngModel)]="couponCode" placeholder="AHORRA10" />
+          </mat-form-field>
+          <div class="flex gap-2">
+            <button mat-stroked-button color="primary" class="flex-1" type="button" (click)="applyCoupon()">
+              Aplicar
+            </button>
+            <button mat-button type="button" class="flex-1" (click)="couponCode = ''">
+              Limpiar
+            </button>
+          </div>
+          <p class="text-sm" [class.text-green-600]="couponSuccess" [class.text-red-500]="!couponSuccess">
+            {{ couponMessage }}
+          </p>
+        </mat-card-content>
+      </mat-card>
+    </aside>
+  </div>
+</div>
+
+<ng-template #emptyState>
+  <mat-card class="rounded-2xl border border-dashed border-gray-200 bg-gray-50">
+    <mat-card-content class="flex flex-col items-center gap-4 py-12">
+      <mat-icon fontSet="material-icons-outlined" class="text-4xl text-gray-400">shopping_cart</mat-icon>
+      <div class="text-center space-y-2">
+        <h2 class="text-xl font-semibold text-gray-900">Tu carrito está vacío</h2>
+        <p class="text-sm text-gray-500">Explora el catálogo y agrega repuestos para continuar con la compra.</p>
+      </div>
+      <a mat-flat-button color="primary" routerLink="/catalogo">Ir al catálogo</a>
+    </mat-card-content>
+  </mat-card>
+</ng-template>

--- a/src/app/features/cart/cart.component.scss
+++ b/src/app/features/cart/cart.component.scss
@@ -1,0 +1,24 @@
+:host {
+  display: block;
+}
+
+header a[mat-stroked-button],
+header button[mat-stroked-button] {
+  text-transform: none;
+}
+
+mat-card {
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 16px 30px -18px rgba(15, 23, 42, 0.4);
+  }
+}
+
+button.mat-mdc-button-base {
+  text-transform: none;
+}
+
+button[mat-stroked-button].bg-blue-50 {
+  border-color: rgba(37, 99, 235, 0.4);
+}

--- a/src/app/features/cart/cart.component.ts
+++ b/src/app/features/cart/cart.component.ts
@@ -1,0 +1,180 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+interface CartItem {
+  id: string;
+  name: string;
+  brand: string;
+  price: number;
+  quantity: number;
+  stock: number;
+  image: string;
+  compatibility: string;
+}
+
+interface ShippingOption {
+  id: string;
+  label: string;
+  description: string;
+  cost: number;
+}
+
+@Component({
+  selector: 'app-cart',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    FormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDividerModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  templateUrl: './cart.component.html',
+  styleUrls: ['./cart.component.scss'],
+})
+export class CartComponent {
+  cartItems: CartItem[] = [
+    {
+      id: 'oil-filter-honda',
+      name: 'Filtro de aceite original',
+      brand: 'Honda',
+      price: 249,
+      quantity: 1,
+      stock: 6,
+      image: 'https://images.unsplash.com/photo-1523924836167-327e0b1ad3d0?auto=format&fit=crop&w=900&q=80',
+      compatibility: 'Civic 2016-2020 · HR-V 2017-2022',
+    },
+    {
+      id: 'brake-pads-toyota',
+      name: 'Pastillas de freno cerámicas',
+      brand: 'Toyota',
+      price: 545,
+      quantity: 2,
+      stock: 12,
+      image: 'https://images.unsplash.com/photo-1580130857273-263566ae5d8b?auto=format&fit=crop&w=900&q=80',
+      compatibility: 'Corolla 2014-2019 · Camry 2015-2020',
+    },
+    {
+      id: 'spark-plugs-hyundai',
+      name: 'Juego de bujías platino',
+      brand: 'Hyundai',
+      price: 365,
+      quantity: 1,
+      stock: 8,
+      image: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80',
+      compatibility: 'Elantra 2017-2022 · Tucson 2018-2023',
+    },
+  ];
+
+  shippingOptions: ShippingOption[] = [
+    {
+      id: 'standard',
+      label: 'Envío estándar',
+      description: 'Entrega en 3-5 días hábiles',
+      cost: 35,
+    },
+    {
+      id: 'express',
+      label: 'Entrega express',
+      description: 'Entrega al siguiente día hábil',
+      cost: 95,
+    },
+    {
+      id: 'pickup',
+      label: 'Recoger en tienda',
+      description: 'Disponible en bodegas zona 9',
+      cost: 0,
+    },
+  ];
+
+  selectedShipping = this.shippingOptions[0];
+  couponCode = '';
+  appliedCoupon: 'AHORRA10' | null = null;
+  couponMessage = 'Ingresa un código para aplicar un descuento.';
+  couponSuccess = false;
+
+  get subtotal(): number {
+    return this.cartItems.reduce((total, item) => total + item.price * item.quantity, 0);
+  }
+
+  get discount(): number {
+    if (this.appliedCoupon === 'AHORRA10') {
+      return Math.min(this.subtotal * 0.1, 50);
+    }
+    return 0;
+  }
+
+  get shippingCost(): number {
+    return this.selectedShipping.cost;
+  }
+
+  get total(): number {
+    return Math.max(this.subtotal - this.discount + this.shippingCost, 0);
+  }
+
+  get totalUnits(): number {
+    return this.cartItems.reduce((total, item) => total + item.quantity, 0);
+  }
+
+  updateQuantity(itemId: string, delta: number): void {
+    this.cartItems = this.cartItems.map((item) => {
+      if (item.id !== itemId) {
+        return item;
+      }
+
+      const nextQuantity = Math.min(Math.max(item.quantity + delta, 1), item.stock);
+      return { ...item, quantity: nextQuantity };
+    });
+  }
+
+  removeItem(itemId: string): void {
+    this.cartItems = this.cartItems.filter((item) => item.id !== itemId);
+  }
+
+  selectShipping(option: ShippingOption): void {
+    this.selectedShipping = option;
+  }
+
+  applyCoupon(): void {
+    const normalized = this.couponCode.trim().toUpperCase();
+
+    if (!normalized) {
+      this.appliedCoupon = null;
+      this.couponMessage = 'Ingresa un código para aplicar un descuento.';
+      this.couponSuccess = false;
+      return;
+    }
+
+    if (normalized === 'AHORRA10') {
+      this.appliedCoupon = 'AHORRA10';
+      this.couponCode = normalized;
+      this.couponMessage = 'Cupón AHORRA10 aplicado · -10% sobre los productos (hasta Q50).';
+      this.couponSuccess = true;
+    } else {
+      this.appliedCoupon = null;
+      this.couponMessage = 'Cupón no reconocido. Verifica el código e inténtalo de nuevo.';
+      this.couponSuccess = false;
+    }
+  }
+
+  clearCart(): void {
+    this.cartItems = [];
+    this.appliedCoupon = null;
+  }
+
+  trackById(_: number, item: CartItem): string {
+    return item.id;
+  }
+}

--- a/src/app/layout/app-layout.component.html
+++ b/src/app/layout/app-layout.component.html
@@ -32,6 +32,12 @@
         <span class="label">Buscar</span>
       </a>
 
+      <a class="menu-item" matRipple routerLink="/carrito" routerLinkActive="active"
+         [matTooltip]="collapsed ? 'Carrito' : ''" matTooltipPosition="right">
+        <mat-icon>shopping_cart</mat-icon>
+        <span class="label">Carrito</span>
+      </a>
+
       <a class="menu-item" matRipple routerLink="/admin" routerLinkActive="active"
          [matTooltip]="collapsed ? 'Alertas' : ''" matTooltipPosition="right">
         <mat-icon>notifications</mat-icon>


### PR DESCRIPTION
## Summary
- add a standalone cart page with mock products, quantity controls, shipping selection, and coupon UI
- register the carrito route and expose it from the layout navigation
- disable Angular CLI analytics after declining telemetry during the build

## Testing
- npm run build *(fails: Angular CLI cannot inline fonts from fonts.googleapis.com because the request returns HTTP 403 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f168db13308330ab4b55023208c4a3