### PR TITLE
feat: add purchases management dashboard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { CartComponent } from './features/cart/cart.component';
 //ADMIN
 import { DashboardComponent } from './features/dashboard/dashboard.component';
 import { InventoryListComponent } from './features/inventory/inventory-list/inventory-list.component';
+import { PurchaseManagementComponent } from './features/purchases/purchase-management.component';
 
 // Guards
 import { authGuard }   from './core/guards/auth.guard';
@@ -37,9 +38,10 @@ export const routes: Routes = [
       { path: 'admin',    component: AdminComponent,  canActivate: [adminGuard] },
       { path: 'catalogo', component: CatalogComponent },
       { path: 'carrito', component: CartComponent },
-      
+
       { path: 'dashboard', component: DashboardComponent },
       { path: 'inventario', component: InventoryListComponent /*, canActivate: [adminGuard]*/ },
+      { path: 'compras', component: PurchaseManagementComponent /*, canActivate: [adminGuard]*/ },
     ]
   }
 ];

--- a/src/app/core/services/purchases.service.ts
+++ b/src/app/core/services/purchases.service.ts
@@ -1,0 +1,280 @@
+// src/app/core/services/purchases.service.ts
+import { Injectable, signal } from '@angular/core';
+import {
+  Purchase,
+  PurchaseStatus,
+  PurchaseTimelineEntry,
+  clonePurchase,
+} from '../../models/purchases/purchase.models';
+
+interface StatusUpdateOptions {
+  nota?: string;
+  fecha?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PurchasesService {
+  private data = signal<Purchase[]>(MOCK_PURCHASES.map((purchase) => clonePurchase(purchase)));
+
+  async list(): Promise<Purchase[]> {
+    const snapshot = this.data().map((purchase) => clonePurchase(purchase));
+    // Simula una llamada a API para mantener coherencia con el resto de servicios
+    return new Promise((resolve) => setTimeout(() => resolve(snapshot), 120));
+  }
+
+  async getById(id: string): Promise<Purchase | null> {
+    const found = this.data().find((purchase) => purchase.id === id);
+    return new Promise((resolve) =>
+      setTimeout(() => resolve(found ? clonePurchase(found) : null), 80)
+    );
+  }
+
+  async updateStatus(id: string, estado: PurchaseStatus, opts: StatusUpdateOptions = {}) {
+    const nowIso = opts.fecha ?? new Date().toISOString();
+
+    this.data.update((current) =>
+      current.map((purchase) => {
+        if (purchase.id !== id) {
+          return purchase;
+        }
+
+        const nextTimeline: PurchaseTimelineEntry[] = [
+          ...purchase.timeline,
+          { estado, fecha: nowIso, descripcion: opts.nota },
+        ];
+
+        return {
+          ...purchase,
+          estado,
+          updatedAt: nowIso,
+          timeline: nextTimeline,
+        };
+      })
+    );
+
+    const updated = this.data().find((purchase) => purchase.id === id);
+    return updated ? clonePurchase(updated) : null;
+  }
+
+  getSuppliers(): string[] {
+    const suppliers = new Set(this.data().map((purchase) => purchase.proveedor));
+    return Array.from(suppliers).sort((a, b) => a.localeCompare(b));
+  }
+}
+
+const MOCK_PURCHASES: Purchase[] = [
+  {
+    id: 'PO-24001',
+    folio: 'PO-24001',
+    proveedor: 'Motorparts Guatemala',
+    warehouse: 'Bodega Central',
+    moneda: 'GTQ',
+    total: 18650,
+    estado: 'en-transito',
+    pagoEstado: 'parcial',
+    metodoPago: 'credito',
+    fecha: '2024-02-02T09:00:00Z',
+    llegadaEstimada: '2024-02-09T15:00:00Z',
+    notas: 'Solicitar inspección de piezas al recibirlas.',
+    createdBy: 'María Flores',
+    updatedAt: '2024-02-05T14:20:00Z',
+    items: [
+      {
+        sku: 'FREN-8401',
+        nombre: 'Kit de frenos cerámicos',
+        categoria: 'Frenos',
+        cantidad: 24,
+        recibido: 0,
+        costoUnitario: 345,
+        fechaEsperada: '2024-02-08T00:00:00Z',
+      },
+      {
+        sku: 'AMOR-2230',
+        nombre: 'Amortiguador trasero',
+        categoria: 'Suspensión',
+        cantidad: 32,
+        recibido: 12,
+        costoUnitario: 410,
+        fechaEsperada: '2024-02-10T00:00:00Z',
+      },
+      {
+        sku: 'ACEI-9981',
+        nombre: 'Aceite sintético 5W-30',
+        categoria: 'Lubricantes',
+        cantidad: 180,
+        recibido: 0,
+        costoUnitario: 68,
+        fechaEsperada: '2024-02-09T00:00:00Z',
+      },
+    ],
+    timeline: [
+      { estado: 'borrador', fecha: '2024-02-01T12:10:00Z', descripcion: 'Solicitud inicial creada.' },
+      { estado: 'ordenado', fecha: '2024-02-01T16:45:00Z', descripcion: 'Orden enviada al proveedor.' },
+      { estado: 'en-transito', fecha: '2024-02-05T14:20:00Z', descripcion: 'Proveedor despachó la orden.' },
+    ],
+    documentos: [
+      { tipo: 'Orden de compra', referencia: 'PO-24001.pdf' },
+      { tipo: 'Factura proforma', referencia: 'FP-5521.pdf' },
+    ],
+  },
+  {
+    id: 'PO-24002',
+    folio: 'PO-24002',
+    proveedor: 'Distribuidora Andina',
+    warehouse: 'Bodega Zona 5',
+    moneda: 'GTQ',
+    total: 9450,
+    estado: 'ordenado',
+    pagoEstado: 'pendiente',
+    metodoPago: 'transferencia',
+    fecha: '2024-02-06T10:30:00Z',
+    llegadaEstimada: '2024-02-17T00:00:00Z',
+    notas: 'Confirmar compatibilidad de piezas con línea Hyundai.',
+    createdBy: 'Luis Pérez',
+    updatedAt: '2024-02-06T10:30:00Z',
+    items: [
+      {
+        sku: 'BUJI-4420',
+        nombre: 'Juego de bujías platino',
+        categoria: 'Motor',
+        cantidad: 60,
+        recibido: 0,
+        costoUnitario: 95,
+        fechaEsperada: '2024-02-16T00:00:00Z',
+      },
+      {
+        sku: 'FILT-7722',
+        nombre: 'Filtro de aire premium',
+        categoria: 'Filtros',
+        cantidad: 40,
+        recibido: 0,
+        costoUnitario: 68,
+        fechaEsperada: '2024-02-17T00:00:00Z',
+      },
+    ],
+    timeline: [
+      { estado: 'borrador', fecha: '2024-02-05T08:15:00Z', descripcion: 'Requisición creada desde ventas.' },
+      { estado: 'ordenado', fecha: '2024-02-06T10:30:00Z', descripcion: 'Compra aprobada y enviada.' },
+    ],
+    documentos: [{ tipo: 'Orden de compra', referencia: 'PO-24002.pdf' }],
+  },
+  {
+    id: 'PO-23988',
+    folio: 'PO-23988',
+    proveedor: 'Repuestos Express',
+    warehouse: 'Bodega Central',
+    moneda: 'GTQ',
+    total: 7240,
+    estado: 'recibido',
+    pagoEstado: 'pagado',
+    metodoPago: 'contado',
+    fecha: '2024-01-18T14:40:00Z',
+    llegadaEstimada: '2024-01-23T00:00:00Z',
+    notas: 'Todo recibido sin incidencias.',
+    createdBy: 'María Flores',
+    updatedAt: '2024-01-22T09:05:00Z',
+    items: [
+      {
+        sku: 'BALA-8820',
+        nombre: 'Banda de distribución',
+        categoria: 'Motor',
+        cantidad: 18,
+        recibido: 18,
+        costoUnitario: 210,
+        fechaEsperada: '2024-01-22T00:00:00Z',
+      },
+      {
+        sku: 'BATE-3309',
+        nombre: 'Batería AGM 70Ah',
+        categoria: 'Eléctrico',
+        cantidad: 10,
+        recibido: 10,
+        costoUnitario: 320,
+        fechaEsperada: '2024-01-22T00:00:00Z',
+      },
+    ],
+    timeline: [
+      { estado: 'borrador', fecha: '2024-01-15T09:00:00Z' },
+      { estado: 'ordenado', fecha: '2024-01-15T11:20:00Z' },
+      { estado: 'en-transito', fecha: '2024-01-20T08:00:00Z' },
+      { estado: 'recibido', fecha: '2024-01-22T09:05:00Z', descripcion: 'Mercadería ingresada a inventario.' },
+    ],
+    documentos: [
+      { tipo: 'Orden de compra', referencia: 'PO-23988.pdf' },
+      { tipo: 'Factura', referencia: 'FE-8872.pdf' },
+    ],
+  },
+  {
+    id: 'PO-23994',
+    folio: 'PO-23994',
+    proveedor: 'Partes y Más',
+    warehouse: 'Bodega Occidente',
+    moneda: 'GTQ',
+    total: 5120,
+    estado: 'cancelado',
+    pagoEstado: 'pendiente',
+    metodoPago: 'transferencia',
+    fecha: '2024-01-25T12:15:00Z',
+    llegadaEstimada: '2024-02-02T00:00:00Z',
+    notas: 'Proveedor sin disponibilidad. Orden cancelada.',
+    createdBy: 'Luis Pérez',
+    updatedAt: '2024-01-26T10:00:00Z',
+    items: [
+      {
+        sku: 'FARO-7120',
+        nombre: 'Faros LED alta luminosidad',
+        categoria: 'Iluminación',
+        cantidad: 20,
+        recibido: 0,
+        costoUnitario: 256,
+        fechaEsperada: '2024-02-02T00:00:00Z',
+      },
+    ],
+    timeline: [
+      { estado: 'borrador', fecha: '2024-01-24T16:00:00Z' },
+      { estado: 'ordenado', fecha: '2024-01-25T12:15:00Z' },
+      { estado: 'cancelado', fecha: '2024-01-26T10:00:00Z', descripcion: 'Proveedor notificó falta de stock.' },
+    ],
+    documentos: [{ tipo: 'Orden de compra', referencia: 'PO-23994.pdf' }],
+  },
+  {
+    id: 'PO-24005',
+    folio: 'PO-24005',
+    proveedor: 'Global Autoparts',
+    warehouse: 'Bodega Central',
+    moneda: 'USD',
+    total: 12680,
+    estado: 'borrador',
+    pagoEstado: 'pendiente',
+    metodoPago: 'credito',
+    fecha: '2024-02-12T08:30:00Z',
+    llegadaEstimada: '2024-02-25T00:00:00Z',
+    notas: 'Revisar lista de precios antes de enviar orden definitiva.',
+    createdBy: 'María Flores',
+    updatedAt: '2024-02-12T08:30:00Z',
+    items: [
+      {
+        sku: 'DISCO-6611',
+        nombre: 'Disco de freno ventilado',
+        categoria: 'Frenos',
+        cantidad: 40,
+        recibido: 0,
+        costoUnitario: 180,
+        fechaEsperada: '2024-02-24T00:00:00Z',
+      },
+      {
+        sku: 'SENS-4218',
+        nombre: 'Sensor ABS trasero',
+        categoria: 'Eléctrico',
+        cantidad: 35,
+        recibido: 0,
+        costoUnitario: 145,
+        fechaEsperada: '2024-02-25T00:00:00Z',
+      },
+    ],
+    timeline: [
+      { estado: 'borrador', fecha: '2024-02-12T08:30:00Z', descripcion: 'Solicitud creada desde inventario.' },
+    ],
+    documentos: [],
+  },
+];

--- a/src/app/features/purchases/purchase-management.component.html
+++ b/src/app/features/purchases/purchase-management.component.html
@@ -1,0 +1,271 @@
+<!-- src/app/features/purchases/purchase-management.component.html -->
+<mat-toolbar color="primary" class="page-toolbar">
+  <div class="toolbar-content">
+    <div class="title-group">
+      <h1>Gestión de compras</h1>
+      <p class="subtitle">Controla órdenes de compra, seguimiento y recepción de mercadería.</p>
+    </div>
+
+    <div class="toolbar-actions">
+      <button mat-stroked-button color="accent" (click)="refresh()" [disabled]="loading()">
+        <mat-icon>refresh</mat-icon>
+        Actualizar
+      </button>
+      <button mat-flat-button color="accent">
+        <mat-icon>add</mat-icon>
+        Nueva compra
+      </button>
+    </div>
+  </div>
+</mat-toolbar>
+
+<mat-progress-bar *ngIf="loading()" mode="indeterminate"></mat-progress-bar>
+
+<div class="page-grid" [class.loading]="loading()">
+  <section class="sidebar">
+    <mat-card class="summary-card" *ngFor="let card of summaryCards(); trackBy: trackBySummary">
+      <div class="summary-icon" [class]="card.tone">
+        <mat-icon>{{ card.icon }}</mat-icon>
+      </div>
+      <div class="summary-body">
+        <p class="summary-label">{{ card.label }}</p>
+        <p class="summary-value">{{ card.value }}</p>
+        <p class="summary-helper" *ngIf="card.helper">{{ card.helper }}</p>
+      </div>
+    </mat-card>
+
+    <mat-card class="filters-card">
+      <div class="card-header">
+        <h2>Filtros</h2>
+        <button mat-button type="button" (click)="clearFilters()">
+          <mat-icon>filter_alt_off</mat-icon>
+          Limpiar
+        </button>
+      </div>
+
+      <mat-form-field appearance="outline" class="filter-field">
+        <mat-label>Búsqueda</mat-label>
+        <input matInput placeholder="Folio, proveedor..." [ngModel]="search()" (ngModelChange)="search.set($event)" />
+        <button mat-icon-button matSuffix *ngIf="search()" (click)="search.set('')" tabindex="-1">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="filter-field">
+        <mat-label>Estado</mat-label>
+        <mat-select [ngModel]="statusFilter()" (ngModelChange)="statusFilter.set($event)">
+          <mat-option *ngFor="let option of statusOptions" [value]="option.value">
+            {{ option.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="filter-field">
+        <mat-label>Proveedor</mat-label>
+        <mat-select [ngModel]="supplierFilter()" (ngModelChange)="supplierFilter.set($event)">
+          <mat-option value="todos">Todos</mat-option>
+          <mat-option *ngFor="let supplier of suppliers()" [value]="supplier">
+            {{ supplierLabel(supplier) }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="filter-field">
+        <mat-label>Periodo</mat-label>
+        <mat-select [ngModel]="periodFilter()" (ngModelChange)="periodFilter.set($event)">
+          <mat-option *ngFor="let option of periodOptions" [value]="option.value">
+            {{ option.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </mat-card>
+  </section>
+
+  <section class="purchases-list">
+    <mat-card class="list-card">
+      <div class="card-header">
+        <div>
+          <h2>Órdenes de compra</h2>
+          <p class="helper">{{ filtered().length }} resultados</p>
+        </div>
+      </div>
+
+      <ng-container *ngIf="filtered().length; else emptyState">
+        <div class="list-wrapper">
+          <article
+            class="purchase-row"
+            *ngFor="let purchase of filtered(); trackBy: trackByPurchase"
+            (click)="selectPurchase(purchase)"
+            [class.active]="selected()?.id === purchase.id"
+          >
+            <div class="row-main">
+              <div class="row-title">
+                <h3>{{ purchase.folio }}</h3>
+                <mat-chip-set>
+                  <mat-chip [ngClass]="getStatusClass(purchase.estado)">
+                    {{ getStatusLabel(purchase.estado) }}
+                  </mat-chip>
+                  <mat-chip [ngClass]="getPaymentClass(purchase.pagoEstado)">
+                    {{ getPaymentLabel(purchase.pagoEstado) }}
+                  </mat-chip>
+                </mat-chip-set>
+              </div>
+              <p class="row-subtitle">{{ purchase.proveedor }} · {{ purchase.warehouse }}</p>
+              <p class="row-date">
+                Creada {{ purchase.fecha | date: 'mediumDate' }} · Actualizada {{ purchase.updatedAt | date: 'short' }}
+              </p>
+            </div>
+
+            <div class="row-stats">
+              <div>
+                <span class="label">Total</span>
+                <span class="value">{{ formatCurrency(purchase.total, purchase.moneda) }}</span>
+              </div>
+              <div>
+                <span class="label">Avance</span>
+                <span class="value">{{ getReceivedPercentage(purchase) }}%</span>
+              </div>
+              <div>
+                <span class="label">Pendiente</span>
+                <span class="value">{{ formatCurrency(getPendingValue(purchase), purchase.moneda) }}</span>
+              </div>
+            </div>
+          </article>
+        </div>
+      </ng-container>
+    </mat-card>
+  </section>
+
+  <section class="purchase-detail" *ngIf="selected() as selection">
+    <mat-card>
+      <div class="detail-header">
+        <div>
+          <p class="detail-date">Actualizado {{ selection.updatedAt | date: 'medium' }}</p>
+          <h2>{{ selection.folio }}</h2>
+          <p class="detail-subtitle">Proveedor: {{ selection.proveedor }} · {{ selection.warehouse }}</p>
+        </div>
+        <mat-chip-set class="status-chips">
+          <mat-chip [ngClass]="getStatusClass(selection.estado)">
+            {{ getStatusLabel(selection.estado) }}
+          </mat-chip>
+          <mat-chip [ngClass]="getPaymentClass(selection.pagoEstado)">
+            {{ getPaymentLabel(selection.pagoEstado) }}
+          </mat-chip>
+        </mat-chip-set>
+      </div>
+
+      <div class="detail-meta">
+        <div>
+          <span class="label">Fecha de emisión</span>
+          <span class="value">{{ selection.fecha | date: 'medium' }}</span>
+        </div>
+        <div>
+          <span class="label">Llegada estimada</span>
+          <span class="value">{{ selection.llegadaEstimada ? (selection.llegadaEstimada | date: 'medium') : 'Por definir' }}</span>
+        </div>
+        <div>
+          <span class="label">Monto total</span>
+          <span class="value">{{ formatCurrency(selection.total, selection.moneda) }}</span>
+        </div>
+        <div>
+          <span class="label">Pendiente</span>
+          <span class="value warning">{{ formatCurrency(getPendingValue(selection), selection.moneda) }}</span>
+        </div>
+        <div>
+          <span class="label">Creado por</span>
+          <span class="value">{{ selection.createdBy }}</span>
+        </div>
+        <div>
+          <span class="label">Notas</span>
+          <span class="value">{{ selection.notas || 'Sin notas' }}</span>
+        </div>
+      </div>
+
+      <div class="detail-actions" *ngIf="nextStatuses().length">
+        <p class="label">Actualizar estado</p>
+        <div class="actions">
+          <button
+            mat-stroked-button
+            color="primary"
+            *ngFor="let status of nextStatuses()"
+            (click)="updateStatus(status)"
+          >
+            <mat-icon>check_circle</mat-icon>
+            {{ getStatusLabel(status) }}
+          </button>
+        </div>
+      </div>
+
+      <section class="items-section">
+        <div class="section-header">
+          <h3>Detalle de artículos</h3>
+          <span>{{ selection.items.length }} ítems · {{ getReceivedPercentage(selection) }}% recibido</span>
+        </div>
+        <div class="items-table">
+          <div class="items-header">
+            <span>SKU</span>
+            <span>Descripción</span>
+            <span class="numeric">Solicitado</span>
+            <span class="numeric">Recibido</span>
+            <span class="numeric">Pendiente</span>
+            <span class="numeric">Total</span>
+          </div>
+          <div class="items-row" *ngFor="let item of selection.items; trackBy: trackByItem">
+            <span class="sku">{{ item.sku }}</span>
+            <div class="description">
+              <p>{{ item.nombre }}</p>
+              <small>{{ item.categoria }}</small>
+              <div class="progress">
+                <mat-progress-bar
+                  mode="determinate"
+                  [value]="item.cantidad ? (item.recibido / item.cantidad) * 100 : 0"
+                ></mat-progress-bar>
+                <small *ngIf="item.fechaEsperada">ETA {{ item.fechaEsperada | date: 'mediumDate' }}</small>
+              </div>
+            </div>
+            <span class="numeric">{{ item.cantidad }}</span>
+            <span class="numeric">{{ item.recibido }}</span>
+            <span class="numeric warning">{{ getPendingUnits(item) }}</span>
+            <span class="numeric">{{ formatCurrency(getItemTotal(item), selection.moneda) }}</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="timeline-section">
+        <div class="section-header">
+          <h3>Historial</h3>
+        </div>
+        <mat-list>
+          <mat-list-item *ngFor="let step of selection.timeline; trackBy: trackByTimeline">
+            <div matListItemIcon class="timeline-icon">
+              <mat-icon>radio_button_checked</mat-icon>
+            </div>
+            <div matListItemTitle>{{ getStatusLabel(step.estado) }}</div>
+            <div matListItemLine>{{ step.fecha | date: 'medium' }}</div>
+            <div matListItemLine *ngIf="step.descripcion" class="timeline-note">{{ step.descripcion }}</div>
+          </mat-list-item>
+        </mat-list>
+      </section>
+
+      <section class="documents-section" *ngIf="selection.documentos?.length">
+        <div class="section-header">
+          <h3>Documentos</h3>
+        </div>
+        <ul>
+          <li *ngFor="let doc of selection.documentos">
+            <mat-icon>description</mat-icon>
+            <span>{{ doc.tipo }} · {{ doc.referencia }}</span>
+          </li>
+        </ul>
+      </section>
+    </mat-card>
+  </section>
+</div>
+
+<ng-template #emptyState>
+  <div class="empty-state">
+    <mat-icon>assignment</mat-icon>
+    <p>No hay compras en este filtro.</p>
+    <button mat-stroked-button color="primary" (click)="clearFilters()">Restablecer filtros</button>
+  </div>
+</ng-template>

--- a/src/app/features/purchases/purchase-management.component.scss
+++ b/src/app/features/purchases/purchase-management.component.scss
@@ -1,0 +1,506 @@
+/* src/app/features/purchases/purchase-management.component.scss */
+:host {
+  display: block;
+  color: #1f2937;
+}
+
+.page-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 0 24px;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.18);
+}
+
+.toolbar-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 24px;
+}
+
+.title-group h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.page-grid {
+  display: grid;
+  grid-template-columns: 300px 1fr 420px;
+  gap: 24px;
+  padding: 24px;
+}
+
+.page-grid.loading {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 16px;
+  background: linear-gradient(140deg, #f3f4f6 0%, #ffffff 80%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.summary-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  flex-shrink: 0;
+}
+
+.summary-icon.primary {
+  background: #2563eb;
+}
+
+.summary-icon.success {
+  background: #16a34a;
+}
+
+.summary-icon.warning {
+  background: #d97706;
+}
+
+.summary-icon.muted {
+  background: #6b7280;
+}
+
+.summary-label {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.summary-value {
+  margin: 4px 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.summary-helper {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.filters-card {
+  padding: 20px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.filter-field {
+  width: 100%;
+}
+
+.purchases-list .list-card {
+  padding: 20px;
+  border-radius: 16px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.helper {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.list-wrapper {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: calc(100vh - 240px);
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.purchase-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+  background: #ffffff;
+}
+
+.purchase-row:hover {
+  border-color: #2563eb;
+  box-shadow: 0 10px 16px rgba(37, 99, 235, 0.1);
+}
+
+.purchase-row.active {
+  border-color: #1d4ed8;
+  box-shadow: 0 12px 20px rgba(29, 78, 216, 0.16);
+}
+
+.row-main {
+  flex: 1;
+}
+
+.row-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.row-title h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.row-subtitle {
+  margin: 6px 0 0;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.row-date {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 0.8rem;
+}
+
+.row-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(100px, auto));
+  gap: 12px;
+  min-width: 240px;
+  text-align: right;
+}
+
+.row-stats .label {
+  display: block;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.row-stats .value {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.purchase-detail mat-card {
+  border-radius: 16px;
+  padding: 24px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.detail-date {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.detail-subtitle {
+  margin: 4px 0 0;
+  color: #4b5563;
+}
+
+.status-chips mat-chip {
+  font-weight: 600;
+}
+
+.detail-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  background: #f9fafb;
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.detail-meta .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #6b7280;
+  letter-spacing: 0.05em;
+}
+
+.detail-meta .value {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.detail-meta .value.warning {
+  color: #d97706;
+}
+
+.detail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.detail-actions .label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.detail-actions .actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.items-section,
+.timeline-section,
+.documents-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.section-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.section-header span {
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.items-table {
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.items-header,
+.items-row {
+  display: grid;
+  grid-template-columns: 120px 1fr repeat(4, 110px);
+  gap: 12px;
+  padding: 12px 16px;
+  align-items: center;
+}
+
+.items-header {
+  background: #f3f4f6;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b7280;
+}
+
+.items-row {
+  border-top: 1px solid #e5e7eb;
+}
+
+.items-row .description p {
+  margin: 0;
+  font-weight: 600;
+}
+
+.items-row .description small {
+  color: #6b7280;
+}
+
+.items-row .progress {
+  margin-top: 4px;
+}
+
+.items-row .progress small {
+  display: block;
+  margin-top: 4px;
+  color: #6b7280;
+}
+
+.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.numeric.warning {
+  color: #d97706;
+  font-weight: 600;
+}
+
+.timeline-icon {
+  color: #2563eb;
+}
+
+.timeline-note {
+  color: #4b5563;
+}
+
+.documents-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.documents-section li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.empty-state {
+  padding: 48px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  color: #6b7280;
+}
+
+.empty-state mat-icon {
+  font-size: 48px;
+  width: 48px;
+  height: 48px;
+}
+
+.chip-neutral {
+  background: #e5e7eb;
+  color: #1f2937;
+}
+
+.chip-info {
+  background: rgba(37, 99, 235, 0.15);
+  color: #1d4ed8;
+}
+
+.chip-warning {
+  background: rgba(217, 119, 6, 0.15);
+  color: #b45309;
+}
+
+.chip-success {
+  background: rgba(22, 163, 74, 0.16);
+  color: #15803d;
+}
+
+.chip-danger {
+  background: rgba(220, 38, 38, 0.16);
+  color: #b91c1c;
+}
+
+@media (max-width: 1280px) {
+  .page-grid {
+    grid-template-columns: 280px 1fr;
+    grid-template-areas:
+      'sidebar list'
+      'sidebar detail';
+  }
+
+  .purchase-detail {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 960px) {
+  .page-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar,
+  .purchases-list,
+  .purchase-detail {
+    grid-column: auto;
+  }
+
+  .list-wrapper {
+    max-height: none;
+  }
+
+  .row-stats {
+    grid-template-columns: repeat(2, minmax(100px, auto));
+  }
+}
+
+@media (max-width: 720px) {
+  .toolbar-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .toolbar-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .items-header,
+  .items-row {
+    grid-template-columns: 100px 1fr repeat(2, 90px);
+    grid-template-areas:
+      'sku desc desc desc'
+      'sku desc desc desc';
+  }
+}

--- a/src/app/features/purchases/purchase-management.component.ts
+++ b/src/app/features/purchases/purchase-management.component.ts
@@ -1,0 +1,377 @@
+// src/app/features/purchases/purchase-management.component.ts
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, computed, effect, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatListModule } from '@angular/material/list';
+
+import {
+  PaymentStatus,
+  Purchase,
+  PurchaseItem,
+  PurchaseStatus,
+  PurchaseTimelineEntry,
+} from '../../models/purchases/purchase.models';
+import { PurchasesService } from '../../core/services/purchases.service';
+
+interface SummaryCard {
+  label: string;
+  value: string;
+  helper?: string;
+  icon: string;
+  tone: 'primary' | 'success' | 'warning' | 'muted';
+}
+
+const STATUS_TRANSITIONS: Record<PurchaseStatus, PurchaseStatus[]> = {
+  borrador: ['ordenado', 'cancelado'],
+  ordenado: ['en-transito', 'cancelado'],
+  'en-transito': ['recibido'],
+  recibido: [],
+  cancelado: [],
+};
+
+const STATUS_LABELS: Record<PurchaseStatus, string> = {
+  borrador: 'Borrador',
+  ordenado: 'Ordenado',
+  'en-transito': 'En tránsito',
+  recibido: 'Recibido',
+  cancelado: 'Cancelado',
+};
+
+const STATUS_CLASS: Record<PurchaseStatus, string> = {
+  borrador: 'chip-neutral',
+  ordenado: 'chip-info',
+  'en-transito': 'chip-warning',
+  recibido: 'chip-success',
+  cancelado: 'chip-danger',
+};
+
+const PAYMENT_LABELS: Record<PaymentStatus, string> = {
+  pendiente: 'Pendiente de pago',
+  parcial: 'Pago parcial',
+  pagado: 'Pagado',
+};
+
+const PAYMENT_CLASS: Record<PaymentStatus, string> = {
+  pendiente: 'chip-warning',
+  parcial: 'chip-info',
+  pagado: 'chip-success',
+};
+
+@Component({
+  selector: 'app-purchase-management',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
+    MatChipsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatDividerModule,
+    MatTooltipModule,
+    MatMenuModule,
+    MatProgressBarModule,
+    MatListModule,
+  ],
+  templateUrl: './purchase-management.component.html',
+  styleUrls: ['./purchase-management.component.scss'],
+})
+export class PurchaseManagementComponent implements OnInit {
+  private purchasesService = inject(PurchasesService);
+
+  loading = signal(true);
+  purchases = signal<Purchase[]>([]);
+
+  search = signal('');
+  statusFilter = signal<PurchaseStatus | 'todos'>('todos');
+  supplierFilter = signal<string | 'todos'>('todos');
+  periodFilter = signal<'30' | '90' | '365' | 'all'>('30');
+
+  selectedId = signal<string | null>(null);
+
+  readonly statusOptions = [
+    { value: 'todos' as const, label: 'Todos los estados' },
+    { value: 'borrador' as const, label: STATUS_LABELS['borrador'] },
+    { value: 'ordenado' as const, label: STATUS_LABELS['ordenado'] },
+    { value: 'en-transito' as const, label: STATUS_LABELS['en-transito'] },
+    { value: 'recibido' as const, label: STATUS_LABELS['recibido'] },
+    { value: 'cancelado' as const, label: STATUS_LABELS['cancelado'] },
+  ];
+
+  readonly periodOptions = [
+    { value: '30' as const, label: 'Últimos 30 días' },
+    { value: '90' as const, label: 'Últimos 90 días' },
+    { value: '365' as const, label: 'Últimos 12 meses' },
+    { value: 'all' as const, label: 'Todo el historial' },
+  ];
+
+  suppliers = computed(() => {
+    const set = new Set(this.purchases().map((purchase) => purchase.proveedor));
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  });
+
+  filtered = computed(() => {
+    const text = this.search().trim().toLowerCase();
+    const status = this.statusFilter();
+    const supplier = this.supplierFilter();
+    const period = this.periodFilter();
+
+    const now = new Date();
+    let fromDate: Date | null = null;
+    if (period !== 'all') {
+      fromDate = new Date(now);
+      fromDate.setDate(now.getDate() - Number(period));
+    }
+
+    return this.purchases()
+      .filter((purchase) => {
+        if (text) {
+          const haystack = `${purchase.folio} ${purchase.proveedor} ${purchase.id}`.toLowerCase();
+          if (!haystack.includes(text)) {
+            return false;
+          }
+        }
+
+        if (status !== 'todos' && purchase.estado !== status) {
+          return false;
+        }
+
+        if (supplier !== 'todos' && purchase.proveedor !== supplier) {
+          return false;
+        }
+
+        if (fromDate) {
+          const purchaseDate = new Date(purchase.fecha);
+          if (purchaseDate < fromDate) {
+            return false;
+          }
+        }
+
+        return true;
+      })
+      .sort((a, b) => new Date(b.fecha).getTime() - new Date(a.fecha).getTime());
+  });
+
+  summaryCards = computed<SummaryCard[]>(() => {
+    const rows = this.purchases();
+    const active = rows.filter((purchase) =>
+      purchase.estado === 'ordenado' || purchase.estado === 'en-transito'
+    );
+
+    const pendingAmount = rows
+      .filter((purchase) => purchase.estado !== 'cancelado')
+      .reduce((acc, purchase) => acc + this.getPendingValue(purchase), 0);
+
+    const now = new Date();
+    const currentMonth = now.getMonth();
+    const currentYear = now.getFullYear();
+    const receivedThisMonth = rows
+      .filter((purchase) => {
+        if (purchase.estado !== 'recibido') {
+          return false;
+        }
+        const updated = new Date(purchase.updatedAt);
+        return updated.getMonth() === currentMonth && updated.getFullYear() === currentYear;
+      })
+      .reduce((acc, purchase) => acc + purchase.total, 0);
+
+    const draftCount = rows.filter((purchase) => purchase.estado === 'borrador').length;
+
+    const suppliers = new Set(rows.map((purchase) => purchase.proveedor));
+
+    return [
+      {
+        label: 'Órdenes activas',
+        value: `${active.length}`,
+        helper: 'En tránsito o pendientes de confirmación',
+        icon: 'local_shipping',
+        tone: 'primary',
+      },
+      {
+        label: 'Pendiente por recibir',
+        value: this.formatCurrency(pendingAmount),
+        helper: 'Valor estimado de unidades faltantes',
+        icon: 'inventory_2',
+        tone: 'warning',
+      },
+      {
+        label: 'Recibido este mes',
+        value: this.formatCurrency(receivedThisMonth),
+        helper: 'Total ingresado al inventario',
+        icon: 'assignment_turned_in',
+        tone: 'success',
+      },
+      {
+        label: 'Borradores activos',
+        value: `${draftCount}`,
+        helper: `${suppliers.size} proveedores en seguimiento`,
+        icon: 'edit_note',
+        tone: 'muted',
+      },
+    ];
+  });
+
+  selected = computed(() => {
+    const currentId = this.selectedId();
+    if (!currentId) {
+      return null;
+    }
+    return this.filtered().find((purchase) => purchase.id === currentId) ?? null;
+  });
+
+  nextStatuses = computed(() => {
+    const selection = this.selected();
+    if (!selection) {
+      return [];
+    }
+    return STATUS_TRANSITIONS[selection.estado];
+  });
+
+  constructor() {
+    effect(() => {
+      const rows = this.filtered();
+      const currentId = this.selectedId();
+      if (rows.length === 0) {
+        if (currentId !== null) {
+          this.selectedId.set(null);
+        }
+        return;
+      }
+
+      const stillVisible = currentId && rows.some((purchase) => purchase.id === currentId);
+      if (!stillVisible) {
+        this.selectedId.set(rows[0].id);
+      }
+    });
+  }
+
+  async ngOnInit(): Promise<void> {
+    await this.fetchPurchases();
+  }
+
+  async fetchPurchases(): Promise<void> {
+    this.loading.set(true);
+    try {
+      const rows = await this.purchasesService.list();
+      this.purchases.set(rows);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  refresh(): void {
+    this.fetchPurchases();
+  }
+
+  selectPurchase(purchase: Purchase): void {
+    this.selectedId.set(purchase.id);
+  }
+
+  clearFilters(): void {
+    this.search.set('');
+    this.statusFilter.set('todos');
+    this.supplierFilter.set('todos');
+    this.periodFilter.set('30');
+  }
+
+  supplierLabel(supplier: string): string {
+    return supplier;
+  }
+
+  formatCurrency(value: number, currency = 'GTQ'): string {
+    return new Intl.NumberFormat('es-GT', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
+  getStatusLabel(status: PurchaseStatus): string {
+    return STATUS_LABELS[status];
+  }
+
+  getStatusClass(status: PurchaseStatus): string {
+    return STATUS_CLASS[status];
+  }
+
+  getPaymentLabel(status: PaymentStatus): string {
+    return PAYMENT_LABELS[status];
+  }
+
+  getPaymentClass(status: PaymentStatus): string {
+    return PAYMENT_CLASS[status];
+  }
+
+  getReceivedPercentage(purchase: Purchase): number {
+    const totalRequested = purchase.items.reduce((acc, item) => acc + item.cantidad, 0);
+    if (totalRequested === 0) {
+      return 0;
+    }
+    const totalReceived = purchase.items.reduce((acc, item) => acc + item.recibido, 0);
+    return Math.round((totalReceived / totalRequested) * 100);
+  }
+
+  getPendingUnits(item: PurchaseItem): number {
+    return Math.max(item.cantidad - item.recibido, 0);
+  }
+
+  getPendingValue(purchase: Purchase): number {
+    return purchase.items.reduce((acc, item) => {
+      const pendingUnits = this.getPendingUnits(item);
+      return acc + pendingUnits * item.costoUnitario;
+    }, 0);
+  }
+
+  getItemTotal(item: PurchaseItem): number {
+    return item.cantidad * item.costoUnitario;
+  }
+
+  trackByPurchase(_: number, purchase: Purchase): string {
+    return purchase.id;
+  }
+
+  trackByItem(_: number, item: PurchaseItem): string {
+    return item.sku;
+  }
+
+  trackBySummary(_: number, card: SummaryCard): string {
+    return card.label;
+  }
+
+  trackByTimeline(_: number, step: PurchaseTimelineEntry): string {
+    return `${step.estado}-${step.fecha}`;
+  }
+
+  async updateStatus(status: PurchaseStatus): Promise<void> {
+    const selection = this.selected();
+    if (!selection) {
+      return;
+    }
+
+    const updated = await this.purchasesService.updateStatus(selection.id, status);
+    if (!updated) {
+      return;
+    }
+
+    this.purchases.update((current) =>
+      current.map((purchase) => (purchase.id === updated.id ? updated : purchase))
+    );
+    this.selectedId.set(updated.id);
+  }
+}

--- a/src/app/layout/app-layout.component.html
+++ b/src/app/layout/app-layout.component.html
@@ -73,6 +73,12 @@
           <mat-icon>inventory_2</mat-icon>
           <span class="label">Inventario</span>
         </a>
+
+        <a class="menu-item" matRipple routerLink="/compras" routerLinkActive="active"
+           [matTooltip]="collapsed ? 'Compras' : ''" matTooltipPosition="right">
+          <mat-icon>shopping_bag</mat-icon>
+          <span class="label">Compras</span>
+        </a>
       </ng-container>
 
       <div class="spacer"></div>

--- a/src/app/models/purchases/purchase.models.ts
+++ b/src/app/models/purchases/purchase.models.ts
@@ -1,0 +1,61 @@
+// src/app/models/purchases/purchase.models.ts
+
+export type PurchaseStatus =
+  | 'borrador'
+  | 'ordenado'
+  | 'en-transito'
+  | 'recibido'
+  | 'cancelado';
+
+export type PaymentStatus = 'pendiente' | 'parcial' | 'pagado';
+
+export interface PurchaseItem {
+  sku: string;
+  nombre: string;
+  categoria: string;
+  cantidad: number;
+  recibido: number;
+  costoUnitario: number;
+  fechaEsperada?: string;
+}
+
+export interface PurchaseTimelineEntry {
+  estado: PurchaseStatus;
+  fecha: string;
+  descripcion?: string;
+}
+
+export interface PurchaseDocument {
+  tipo: string;
+  referencia: string;
+  url?: string;
+}
+
+export interface Purchase {
+  id: string;
+  folio: string;
+  proveedor: string;
+  warehouse: string;
+  moneda: string;
+  total: number;
+  estado: PurchaseStatus;
+  pagoEstado: PaymentStatus;
+  metodoPago: 'contado' | 'credito' | 'transferencia';
+  fecha: string;
+  llegadaEstimada?: string;
+  notas?: string;
+  createdBy: string;
+  updatedAt: string;
+  items: PurchaseItem[];
+  timeline: PurchaseTimelineEntry[];
+  documentos?: PurchaseDocument[];
+}
+
+export function clonePurchase(p: Purchase): Purchase {
+  return {
+    ...p,
+    items: p.items.map((item) => ({ ...item })),
+    timeline: p.timeline.map((step) => ({ ...step })),
+    documentos: p.documentos?.map((doc) => ({ ...doc })),
+  };
+}


### PR DESCRIPTION
## Summary
- introduce purchase order models and a mock service to simulate status updates
- build a standalone purchases management workspace with filters, analytics, and detailed timelines
- expose the purchases section through application routing and the authenticated navigation menu

## Testing
- npm run build *(fails: external Roboto font download blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f16dc75f5c8330a6bc575111f67e96