### PR TITLE
Add inventory and advertising feature modules

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,7 +12,6 @@ import { CartComponent } from './features/cart/cart.component';
 
 //ADMIN
 import { DashboardComponent } from './features/dashboard/dashboard.component';
-import { InventoryListComponent } from './features/inventory/inventory-list/inventory-list.component';
 import { PurchaseManagementComponent } from './features/purchases/purchase-management.component';
 
 // Guards
@@ -40,7 +39,18 @@ export const routes: Routes = [
       { path: 'carrito', component: CartComponent },
 
       { path: 'dashboard', component: DashboardComponent },
-      { path: 'inventario', component: InventoryListComponent /*, canActivate: [adminGuard]*/ },
+      {
+        path: 'inventario',
+        loadChildren: () =>
+          import('./features/inventory/inventory.module').then((m) => m.InventoryModule),
+        // canActivate: [adminGuard],
+      },
+      {
+        path: 'publicidad',
+        loadChildren: () =>
+          import('./features/advertising/advertising.module').then((m) => m.AdvertisingModule),
+        // canActivate: [adminGuard],
+      },
       { path: 'compras', component: PurchaseManagementComponent /*, canActivate: [adminGuard]*/ },
     ]
   }

--- a/src/app/features/advertising/advertising.component.html
+++ b/src/app/features/advertising/advertising.component.html
@@ -1,0 +1,154 @@
+<div class="page">
+  <mat-toolbar color="primary" class="toolbar">
+    <div class="toolbar-main">
+      <div class="title">
+        <mat-icon>campaign</mat-icon>
+        <div class="heading">
+          <h1>Publicidad y campañas</h1>
+          <p class="subtitle">Monitorea el rendimiento de tus campañas activas y planificadas.</p>
+        </div>
+      </div>
+    </div>
+    <div class="toolbar-actions">
+      <button mat-stroked-button color="primary">
+        <mat-icon>add</mat-icon>
+        Nueva campaña
+      </button>
+      <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Más acciones">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+    </div>
+  </mat-toolbar>
+
+  <mat-menu #menu="matMenu">
+    <button mat-menu-item>
+      <mat-icon>file_download</mat-icon>
+      <span>Exportar reporte</span>
+    </button>
+    <button mat-menu-item>
+      <mat-icon>notifications_active</mat-icon>
+      <span>Configurar alertas</span>
+    </button>
+  </mat-menu>
+
+  <div class="summary">
+    <mat-card class="summary-card" appearance="outlined">
+      <div class="label">Campañas activas</div>
+      <div class="value">{{ stats().active }}</div>
+      <div class="helper">de {{ stats().totalCampaigns }} totales</div>
+    </mat-card>
+
+    <mat-card class="summary-card" appearance="outlined">
+      <div class="label">Presupuesto invertido</div>
+      <div class="value">{{ stats().spent | currency:'MXN':'symbol-narrow' }}</div>
+      <mat-progress-bar mode="determinate" [value]="stats().spendRatio"></mat-progress-bar>
+      <div class="helper">{{ stats().spendRatio | number:'1.0-1' }}% del presupuesto asignado</div>
+    </mat-card>
+
+    <mat-card class="summary-card" appearance="outlined">
+      <div class="label">CTR promedio</div>
+      <div class="value">{{ stats().ctr | number:'1.1-2' }}%</div>
+      <div class="helper">{{ stats().clicks | number }} clics / {{ stats().impressions | number }} impresiones</div>
+    </mat-card>
+
+    <mat-card class="summary-card" appearance="outlined">
+      <div class="label">Conversiones</div>
+      <div class="value">{{ stats().conversions | number }}</div>
+      <div class="helper">Tasa de conversión {{ stats().cvr | number:'1.1-2' }}%</div>
+    </mat-card>
+  </div>
+
+  <div class="content">
+    <section class="panel">
+      <div class="panel-header">
+        <h2>Campañas en curso</h2>
+        <button mat-button color="primary">
+          <mat-icon>insights</mat-icon>
+          Ver analíticas detalladas
+        </button>
+      </div>
+
+      <div class="campaign-grid" *ngIf="runningCampaigns().length; else empty">
+        <mat-card *ngFor="let campaign of runningCampaigns()" appearance="outlined" class="campaign-card">
+          <div class="card-header">
+            <div class="title">
+              <mat-icon>{{ channelIcon(campaign.channel) }}</mat-icon>
+              <div>
+                <h3>{{ campaign.name }}</h3>
+                <span class="meta">Desde {{ campaign.startDate | date:'d MMM y' }}</span>
+              </div>
+            </div>
+            <span class="status" [class]="statusClass(campaign.status)">
+              {{ statusLabel(campaign.status) }}
+            </span>
+          </div>
+
+          <div class="metrics">
+            <div>
+              <span class="label">Impresiones</span>
+              <span class="value">{{ campaign.impressions | number }}</span>
+            </div>
+            <div>
+              <span class="label">Clics</span>
+              <span class="value">{{ campaign.clicks | number }}</span>
+            </div>
+            <div>
+              <span class="label">Conversiones</span>
+              <span class="value">{{ campaign.conversions | number }}</span>
+            </div>
+            <div>
+              <span class="label">Gasto</span>
+              <span class="value">{{ campaign.spent | currency:'MXN':'symbol-narrow' }}</span>
+            </div>
+          </div>
+
+          <mat-divider></mat-divider>
+
+          <div class="actions">
+            <button mat-button>Editar</button>
+            <button mat-button>Duplicar</button>
+            <button mat-button color="warn">Pausar</button>
+          </div>
+        </mat-card>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h2>Campañas planificadas y recientes</h2>
+      </div>
+
+      <mat-list class="campaign-list">
+        <mat-list-item *ngFor="let campaign of otherCampaigns()">
+          <mat-icon matListItemIcon>{{ channelIcon(campaign.channel) }}</mat-icon>
+          <div matListItemTitle>
+            {{ campaign.name }}
+            <span class="status small" [class]="statusClass(campaign.status)">
+              {{ statusLabel(campaign.status) }}
+            </span>
+          </div>
+          <div matListItemLine class="secondary">
+            Presupuesto {{ campaign.budget | currency:'MXN':'symbol-narrow' }} · Inicio {{ campaign.startDate | date:'mediumDate' }}
+            <ng-container *ngIf="campaign.endDate">
+              · Fin {{ campaign.endDate | date:'mediumDate' }}
+            </ng-container>
+          </div>
+          <div matListItemMeta>
+            <button mat-icon-button aria-label="Ver detalles">
+              <mat-icon>open_in_new</mat-icon>
+            </button>
+          </div>
+        </mat-list-item>
+      </mat-list>
+    </section>
+  </div>
+</div>
+
+<ng-template #empty>
+  <mat-card class="empty" appearance="outlined">
+    <mat-icon>schedule</mat-icon>
+    <h3>No hay campañas activas</h3>
+    <p>Planifica una nueva campaña o reactiva una existente para comenzar a medir resultados.</p>
+    <button mat-raised-button color="primary">Crear campaña</button>
+  </mat-card>
+</ng-template>

--- a/src/app/features/advertising/advertising.component.scss
+++ b/src/app/features/advertising/advertising.component.scss
@@ -1,0 +1,264 @@
+:host {
+  display: block;
+  min-height: 100%;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+}
+
+.toolbar {
+  border-radius: 16px;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 10px 30px rgba(25, 118, 210, 0.18);
+}
+
+.toolbar-main {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.title mat-icon {
+  font-size: 48px;
+  width: 48px;
+  height: 48px;
+}
+
+.heading h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.heading .subtitle {
+  margin: 4px 0 0;
+  opacity: 0.85;
+}
+
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.summary {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.summary-card {
+  padding: 20px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-card .label {
+  font-weight: 600;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.summary-card .value {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.summary-card .helper {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 13px;
+}
+
+.content {
+  display: grid;
+  gap: 24px;
+}
+
+.panel {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.campaign-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.campaign-card {
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.card-header .title {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.card-header .title mat-icon {
+  font-size: 36px;
+  width: 36px;
+  height: 36px;
+}
+
+.card-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.card-header .meta {
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.status {
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.status.small {
+  font-size: 11px;
+  padding: 3px 8px;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.metrics .label {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.metrics .value {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.campaign-list {
+  padding: 0;
+}
+
+.campaign-list mat-list-item {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.campaign-list mat-list-item:last-child {
+  border-bottom: none;
+}
+
+.campaign-list .secondary {
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.empty {
+  margin: 24px auto;
+  padding: 32px;
+  text-align: center;
+  display: grid;
+  gap: 16px;
+  max-width: 360px;
+}
+
+.empty mat-icon {
+  font-size: 48px;
+  width: 48px;
+  height: 48px;
+  margin: 0 auto;
+  color: rgba(25, 118, 210, 0.8);
+}
+
+.chip-muted {
+  background: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.chip-info {
+  background: rgba(33, 150, 243, 0.15);
+  color: #1565c0;
+}
+
+.chip-success {
+  background: rgba(46, 125, 50, 0.15);
+  color: #1b5e20;
+}
+
+.chip-warning {
+  background: rgba(255, 152, 0, 0.18);
+  color: #e65100;
+}
+
+.chip-neutral {
+  background: rgba(120, 144, 156, 0.16);
+  color: #37474f;
+}
+
+@media (max-width: 768px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .panel {
+    padding: 16px;
+  }
+
+  .campaign-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  }
+}

--- a/src/app/features/advertising/advertising.component.ts
+++ b/src/app/features/advertising/advertising.component.ts
@@ -1,0 +1,169 @@
+import { Component, computed, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatListModule } from '@angular/material/list';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
+interface Campaign {
+  id: string;
+  name: string;
+  channel: 'social' | 'search' | 'email' | 'display';
+  status: 'draft' | 'scheduled' | 'running' | 'paused' | 'completed';
+  budget: number;
+  spent: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  startDate: string;
+  endDate?: string;
+}
+
+const STATUS_LABEL: Record<Campaign['status'], string> = {
+  draft: 'Borrador',
+  scheduled: 'Programada',
+  running: 'Activa',
+  paused: 'Pausada',
+  completed: 'Completada',
+};
+
+const STATUS_CLASS: Record<Campaign['status'], string> = {
+  draft: 'chip-muted',
+  scheduled: 'chip-info',
+  running: 'chip-success',
+  paused: 'chip-warning',
+  completed: 'chip-neutral',
+};
+
+const CHANNEL_ICON: Record<Campaign['channel'], string> = {
+  social: 'groups',
+  search: 'travel_explore',
+  email: 'mail',
+  display: 'monitor',
+};
+
+@Component({
+  selector: 'app-advertising',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
+    MatCardModule,
+    MatChipsModule,
+    MatMenuModule,
+    MatDividerModule,
+    MatListModule,
+    MatProgressBarModule,
+  ],
+  templateUrl: './advertising.component.html',
+  styleUrls: ['./advertising.component.scss'],
+})
+export class AdvertisingComponent {
+  private campaigns = signal<Campaign[]>([
+    {
+      id: 'cmp-001',
+      name: 'Lanzamiento colección verano',
+      channel: 'social',
+      status: 'running',
+      budget: 45000,
+      spent: 27500,
+      impressions: 890000,
+      clicks: 74000,
+      conversions: 3200,
+      startDate: '2024-05-01',
+    },
+    {
+      id: 'cmp-002',
+      name: 'Remarketing carrito abandonado',
+      channel: 'email',
+      status: 'scheduled',
+      budget: 12000,
+      spent: 0,
+      impressions: 0,
+      clicks: 0,
+      conversions: 0,
+      startDate: '2024-07-05',
+    },
+    {
+      id: 'cmp-003',
+      name: 'Promoción SEO marketplace',
+      channel: 'search',
+      status: 'completed',
+      budget: 18000,
+      spent: 17450,
+      impressions: 410000,
+      clicks: 19000,
+      conversions: 980,
+      startDate: '2024-03-10',
+      endDate: '2024-04-25',
+    },
+    {
+      id: 'cmp-004',
+      name: 'Campaña display regional',
+      channel: 'display',
+      status: 'paused',
+      budget: 22000,
+      spent: 7800,
+      impressions: 150000,
+      clicks: 5800,
+      conversions: 220,
+      startDate: '2024-06-01',
+    },
+  ]);
+
+  readonly stats = computed(() => {
+    const rows = this.campaigns();
+    const active = rows.filter((campaign) => campaign.status === 'running');
+    const scheduled = rows.filter((campaign) => campaign.status === 'scheduled');
+    const spent = rows.reduce((acc, campaign) => acc + campaign.spent, 0);
+    const budget = rows.reduce((acc, campaign) => acc + campaign.budget, 0);
+    const impressions = rows.reduce((acc, campaign) => acc + campaign.impressions, 0);
+    const clicks = rows.reduce((acc, campaign) => acc + campaign.clicks, 0);
+    const conversions = rows.reduce((acc, campaign) => acc + campaign.conversions, 0);
+
+    const ctr = impressions ? (clicks / impressions) * 100 : 0;
+    const cvr = clicks ? (conversions / clicks) * 100 : 0;
+    const spendRatio = budget ? (spent / budget) * 100 : 0;
+
+    return {
+      totalCampaigns: rows.length,
+      active: active.length,
+      scheduled: scheduled.length,
+      spent,
+      budget,
+      spendRatio,
+      impressions,
+      clicks,
+      ctr,
+      conversions,
+      cvr,
+    };
+  });
+
+  readonly runningCampaigns = computed(() =>
+    this.campaigns().filter((campaign) => campaign.status === 'running')
+  );
+
+  readonly otherCampaigns = computed(() =>
+    this.campaigns().filter((campaign) => campaign.status !== 'running')
+  );
+
+  channelIcon(channel: Campaign['channel']) {
+    return CHANNEL_ICON[channel];
+  }
+
+  statusLabel(status: Campaign['status']) {
+    return STATUS_LABEL[status];
+  }
+
+  statusClass(status: Campaign['status']) {
+    return STATUS_CLASS[status];
+  }
+}

--- a/src/app/features/advertising/advertising.module.ts
+++ b/src/app/features/advertising/advertising.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AdvertisingComponent } from './advertising.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: AdvertisingComponent,
+  },
+];
+
+@NgModule({
+  imports: [AdvertisingComponent, RouterModule.forChild(routes)],
+})
+export class AdvertisingModule {}

--- a/src/app/features/inventory/inventory.module.ts
+++ b/src/app/features/inventory/inventory.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { InventoryListComponent } from './inventory-list/inventory-list.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: InventoryListComponent,
+  },
+];
+
+@NgModule({
+  imports: [InventoryListComponent, RouterModule.forChild(routes)],
+})
+export class InventoryModule {}

--- a/src/app/layout/app-layout.component.html
+++ b/src/app/layout/app-layout.component.html
@@ -74,6 +74,12 @@
           <span class="label">Inventario</span>
         </a>
 
+        <a class="menu-item" matRipple routerLink="/publicidad" routerLinkActive="active"
+           [matTooltip]="collapsed ? 'Publicidad' : ''" matTooltipPosition="right">
+          <mat-icon>campaign</mat-icon>
+          <span class="label">Publicidad</span>
+        </a>
+
         <a class="menu-item" matRipple routerLink="/compras" routerLinkActive="active"
            [matTooltip]="collapsed ? 'Compras' : ''" matTooltipPosition="right">
           <mat-icon>shopping_bag</mat-icon>


### PR DESCRIPTION
## Summary
- add an inventory feature module and update routing to lazy load it
- create an advertising feature with dashboard-style component and module
- expose the advertising section through the main navigation

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/... returned status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f182c02dcc83309123f2fd3b3e4462