### PR TITLE
feat: add users module with list view

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -51,6 +51,12 @@ export const routes: Routes = [
           import('./features/advertising/advertising.module').then((m) => m.AdvertisingModule),
         // canActivate: [adminGuard],
       },
+      {
+        path: 'usuarios',
+        loadChildren: () =>
+          import('./features/users/users.module').then((m) => m.UsersModule),
+        canActivate: [adminGuard],
+      },
       { path: 'compras', component: PurchaseManagementComponent /*, canActivate: [adminGuard]*/ },
     ]
   }

--- a/src/app/core/services/users.service.ts
+++ b/src/app/core/services/users.service.ts
@@ -1,0 +1,34 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+import { mapUserApiToUser, User, UserApi } from '../../models/users/user.model';
+
+interface UsersResponse {
+  data?: UserApi[];
+  meta?: unknown;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UsersService {
+  private readonly http = inject(HttpClient);
+  private readonly API = environment.apiBaseUrl;
+
+  async list(opts: { query?: string } = {}): Promise<User[]> {
+    let params = new HttpParams();
+    if (opts.query) {
+      params = params.set('filters[$or][0][username][$containsi]', opts.query)
+        .set('filters[$or][1][email][$containsi]', opts.query)
+        .set('filters[$or][2][firstName][$containsi]', opts.query)
+        .set('filters[$or][3][lastName][$containsi]', opts.query);
+    }
+
+    const res = await firstValueFrom(
+      this.http.get<UserApi[] | UsersResponse>(`${this.API}/users`, { params })
+    );
+
+    const items = Array.isArray(res) ? res : res.data ?? [];
+    return items.map(mapUserApiToUser);
+  }
+}

--- a/src/app/features/users/user-list/user-list.component.html
+++ b/src/app/features/users/user-list/user-list.component.html
@@ -1,0 +1,95 @@
+<mat-toolbar color="primary" class="user-toolbar">
+  <span class="title">Usuarios</span>
+  <span class="spacer"></span>
+  <button mat-icon-button matTooltip="Actualizar" (click)="fetchUsers()" [disabled]="loading()">
+    <mat-icon>refresh</mat-icon>
+  </button>
+</mat-toolbar>
+
+<mat-progress-bar *ngIf="loading()" mode="indeterminate"></mat-progress-bar>
+
+<mat-card>
+  <div class="filters">
+    <mat-form-field appearance="outline" class="search">
+      <mat-label>Buscar</mat-label>
+      <input
+        matInput
+        placeholder="Usuario, correo o nombre"
+        [(ngModel)]="queryValue"
+      />
+      <button
+        *ngIf="queryValue"
+        mat-icon-button
+        matSuffix
+        matTooltip="Limpiar"
+        (click)="queryValue = '';"
+      >
+        <mat-icon>clear</mat-icon>
+      </button>
+    </mat-form-field>
+    <span class="results" *ngIf="filteredUsers().length !== users().length">
+      Mostrando {{ filteredUsers().length }} de {{ users().length }} usuarios
+    </span>
+  </div>
+
+  <div class="table-container" *ngIf="filteredUsers().length; else emptyState">
+    <table mat-table [dataSource]="filteredUsers()" class="mat-elevation-z1">
+      <ng-container matColumnDef="username">
+        <th mat-header-cell *matHeaderCellDef> Usuario </th>
+        <td mat-cell *matCellDef="let user">{{ user.username }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="email">
+        <th mat-header-cell *matHeaderCellDef> Correo </th>
+        <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="fullName">
+        <th mat-header-cell *matHeaderCellDef> Nombre </th>
+        <td mat-cell *matCellDef="let user">{{ user.fullName || '—' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="provider">
+        <th mat-header-cell *matHeaderCellDef> Proveedor </th>
+        <td mat-cell *matCellDef="let user">{{ user.provider }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef> Estado </th>
+        <td mat-cell *matCellDef="let user" class="status-cell">
+          <mat-chip color="primary" [selected]="user.confirmed" [disabled]="!user.confirmed">
+            {{ user.confirmed ? 'Confirmado' : 'Sin confirmar' }}
+          </mat-chip>
+          <mat-chip color="warn" *ngIf="user.blocked">Bloqueado</mat-chip>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="timestamps">
+        <th mat-header-cell *matHeaderCellDef> Fechas </th>
+        <td mat-cell *matCellDef="let user">
+          <div class="timestamps">
+            <span><strong>Creado:</strong> {{ user.createdAt | date:'short' }}</span>
+            <span><strong>Actualizado:</strong> {{ user.updatedAt | date:'short' }}</span>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns; trackBy: trackById"></tr>
+    </table>
+  </div>
+</mat-card>
+
+<ng-template #emptyState>
+  <div class="empty-state" *ngIf="!loading(); else loadingState">
+    <mat-icon>group_off</mat-icon>
+    <p>No se encontraron usuarios.</p>
+  </div>
+</ng-template>
+
+<ng-template #loadingState>
+  <div class="loading-state">
+    <mat-icon>hourglass_empty</mat-icon>
+    <p>Cargando usuarios...</p>
+  </div>
+</ng-template>

--- a/src/app/features/users/user-list/user-list.component.scss
+++ b/src/app/features/users/user-list/user-list.component.scss
@@ -1,0 +1,79 @@
+.user-toolbar {
+  margin-bottom: 1rem;
+
+  .title {
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+
+  .spacer {
+    flex: 1 1 auto;
+  }
+}
+
+mat-card {
+  padding: 1rem;
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+
+  .search {
+    flex: 1 1 280px;
+  }
+
+  .results {
+    color: rgba(0, 0, 0, 0.6);
+    font-size: 0.9rem;
+  }
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+
+  th {
+    font-weight: 600;
+  }
+
+  td,
+  th {
+    padding: 0.75rem;
+  }
+}
+
+.status-cell {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.timestamps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.empty-state,
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: rgba(0, 0, 0, 0.6);
+  padding: 2rem 0;
+
+  mat-icon {
+    font-size: 3rem;
+    width: 3rem;
+    height: 3rem;
+  }
+}

--- a/src/app/features/users/user-list/user-list.component.ts
+++ b/src/app/features/users/user-list/user-list.component.ts
@@ -1,0 +1,89 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { MatTableModule } from '@angular/material/table';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { UsersService } from '../../../core/services/users.service';
+import { User } from '../../../models/users/user.model';
+
+@Component({
+  selector: 'app-user-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatTableModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressBarModule,
+    MatChipsModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './user-list.component.html',
+  styleUrls: ['./user-list.component.scss'],
+})
+export class UserListComponent implements OnInit {
+  private readonly usersService = inject(UsersService);
+
+  readonly displayedColumns = ['username', 'email', 'fullName', 'provider', 'status', 'timestamps'];
+
+  readonly users = signal<User[]>([]);
+  readonly loading = signal(false);
+  readonly query = signal('');
+
+  readonly filteredUsers = computed(() => {
+    const search = this.query().trim().toLowerCase();
+    if (!search) {
+      return this.users();
+    }
+    return this.users().filter((user) =>
+      [user.username, user.email, user.fullName]
+        .filter(Boolean)
+        .some((value) => value.toLowerCase().includes(search))
+    );
+  });
+
+  get queryValue(): string {
+    return this.query();
+  }
+
+  set queryValue(value: string) {
+    this.onQueryChange(value);
+  }
+
+  ngOnInit(): void {
+    this.fetchUsers();
+  }
+
+  async fetchUsers(): Promise<void> {
+    this.loading.set(true);
+    try {
+      const users = await this.usersService.list();
+      this.users.set(users);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  onQueryChange(value: string): void {
+    this.query.set(value);
+  }
+
+  trackById(_: number, user: User): number {
+    return user.id;
+  }
+}

--- a/src/app/features/users/users.module.ts
+++ b/src/app/features/users/users.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { UserListComponent } from './user-list/user-list.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: UserListComponent,
+  }
+];
+
+@NgModule({
+  imports: [UserListComponent, RouterModule.forChild(routes)],
+})
+export class UsersModule {}

--- a/src/app/models/users/user.model.ts
+++ b/src/app/models/users/user.model.ts
@@ -1,0 +1,42 @@
+export interface UserApi {
+  id: number;
+  documentId: string;
+  provider: string;
+  confirmed: boolean;
+  blocked: boolean;
+  username: string;
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+}
+
+export interface User {
+  id: number;
+  documentId: string;
+  provider: string;
+  confirmed: boolean;
+  blocked: boolean;
+  username: string;
+  email: string;
+  fullName: string;
+  createdAt: Date;
+  updatedAt: Date;
+  publishedAt: Date;
+}
+
+export const mapUserApiToUser = (api: UserApi): User => ({
+  id: api.id,
+  documentId: api.documentId,
+  provider: api.provider,
+  confirmed: api.confirmed,
+  blocked: api.blocked,
+  username: api.username,
+  email: api.email,
+  fullName: `${api.firstName ?? ''} ${api.lastName ?? ''}`.trim(),
+  createdAt: new Date(api.createdAt),
+  updatedAt: new Date(api.updatedAt),
+  publishedAt: new Date(api.publishedAt),
+});


### PR DESCRIPTION
## Summary
- add a users data model and service to integrate with the Strapi users endpoint
- introduce a standalone user list component and lazy loaded module for managing users
- register the new /usuarios route under the admin section guarded for admin access

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f1c5b503908330a016eea4dff7d5c0