### PR TITLE
feat: enable user management actions

### DIFF
--- a/src/app/core/services/users.service.ts
+++ b/src/app/core/services/users.service.ts
@@ -3,7 +3,27 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
 import { environment } from '../../../environments/environment';
-import { mapUserApiToUser, User, UserApi } from '../../models/users/user.model';
+import {
+  mapUserApiToUser,
+  User,
+  UserApi,
+} from '../../models/users/user.model';
+
+export interface CreateUserPayload {
+  username: string;
+  email: string;
+  password: string;
+  provider?: string;
+  confirmed?: boolean;
+  blocked?: boolean;
+  firstName?: string | null;
+  lastName?: string | null;
+  role?: string | number | null;
+}
+
+export type UpdateUserPayload = Partial<Omit<CreateUserPayload, 'password'>> & {
+  password?: string;
+};
 
 interface UsersResponse {
   data?: UserApi[];
@@ -30,5 +50,21 @@ export class UsersService {
 
     const items = Array.isArray(res) ? res : res.data ?? [];
     return items.map(mapUserApiToUser);
+  }
+
+  async create(payload: CreateUserPayload): Promise<User> {
+    const res = await firstValueFrom(
+      this.http.post<UserApi>(`${this.API}/users`, payload)
+    );
+
+    return mapUserApiToUser(res);
+  }
+
+  async update(id: number, payload: UpdateUserPayload): Promise<User> {
+    const res = await firstValueFrom(
+      this.http.put<UserApi>(`${this.API}/users/${id}`, payload)
+    );
+
+    return mapUserApiToUser(res);
   }
 }

--- a/src/app/features/users/user-form-dialog/user-form-dialog.component.html
+++ b/src/app/features/users/user-form-dialog/user-form-dialog.component.html
@@ -1,0 +1,84 @@
+<h2 mat-dialog-title>{{ isEditMode ? 'Editar usuario' : 'Crear usuario' }}</h2>
+
+<form [formGroup]="form" (ngSubmit)="save()" class="user-form">
+  <mat-dialog-content>
+    <div class="form-grid">
+      <mat-form-field appearance="outline">
+        <mat-label>Usuario</mat-label>
+        <input matInput formControlName="username" autocomplete="off" />
+        <mat-error *ngIf="form.get('username')?.hasError('required')">
+          El usuario es obligatorio
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Correo electrónico</mat-label>
+        <input matInput formControlName="email" autocomplete="off" />
+        <mat-error *ngIf="form.get('email')?.hasError('required')">
+          El correo es obligatorio
+        </mat-error>
+        <mat-error *ngIf="form.get('email')?.hasError('email')">
+          Ingresa un correo válido
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" *ngIf="!isEditMode">
+        <mat-label>Contraseña</mat-label>
+        <input matInput type="password" formControlName="password" />
+        <mat-error *ngIf="form.get('password')?.hasError('required')">
+          La contraseña es obligatoria
+        </mat-error>
+        <mat-error *ngIf="form.get('password')?.hasError('minlength')">
+          Debe tener al menos 6 caracteres
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" *ngIf="isEditMode">
+        <mat-label>Nueva contraseña (opcional)</mat-label>
+        <input matInput type="password" formControlName="password" />
+        <mat-hint>Déjala vacía para mantener la actual</mat-hint>
+        <mat-error *ngIf="form.get('password')?.hasError('minlength')">
+          Debe tener al menos 6 caracteres
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Nombre</mat-label>
+        <input matInput formControlName="firstName" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Apellido</mat-label>
+        <input matInput formControlName="lastName" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Rol</mat-label>
+        <input matInput formControlName="role" placeholder="ID de rol" />
+      </mat-form-field>
+    </div>
+
+    <div class="toggles">
+      <mat-checkbox formControlName="confirmed">Confirmado</mat-checkbox>
+      <mat-checkbox formControlName="blocked">Bloqueado</mat-checkbox>
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="cancel()" [disabled]="loading()">Cancelar</button>
+    <button
+      mat-flat-button
+      color="primary"
+      type="submit"
+      [disabled]="loading() || form.invalid"
+    >
+      <mat-icon *ngIf="!loading()">save</mat-icon>
+      <span *ngIf="!loading()">Guardar</span>
+      <mat-progress-spinner
+        *ngIf="loading()"
+        diameter="20"
+        mode="indeterminate"
+      ></mat-progress-spinner>
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/src/app/features/users/user-form-dialog/user-form-dialog.component.scss
+++ b/src/app/features/users/user-form-dialog/user-form-dialog.component.scss
@@ -1,0 +1,28 @@
+.user-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.toggles {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+mat-dialog-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+button[mat-flat-button] {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/src/app/features/users/user-form-dialog/user-form-dialog.component.ts
+++ b/src/app/features/users/user-form-dialog/user-form-dialog.component.ts
@@ -1,0 +1,108 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { UsersService } from '../../../core/services/users.service';
+import { User } from '../../../models/users/user.model';
+
+@Component({
+  selector: 'app-user-form-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatCheckboxModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSnackBarModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './user-form-dialog.component.html',
+  styleUrls: ['./user-form-dialog.component.scss'],
+})
+export class UserFormDialogComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly usersService = inject(UsersService);
+  private readonly dialogRef = inject(MatDialogRef<UserFormDialogComponent>);
+  private readonly data = inject<User | null>(MAT_DIALOG_DATA, { optional: true }) ?? null;
+
+  readonly loading = signal(false);
+
+  readonly form = this.fb.group({
+    id: [this.data?.id ?? null],
+    username: [this.data?.username ?? '', [Validators.required, Validators.maxLength(120)]],
+    email: [
+      this.data?.email ?? '',
+      [Validators.required, Validators.email, Validators.maxLength(255)],
+    ],
+    password: ['', this.data ? [] : [Validators.required, Validators.minLength(6)]],
+    firstName: [this.data?.firstName ?? ''],
+    lastName: [this.data?.lastName ?? ''],
+    role: [this.data?.roleId != null ? String(this.data.roleId) : ''],
+    confirmed: [this.data?.confirmed ?? true],
+    blocked: [this.data?.blocked ?? false],
+  });
+
+  get isEditMode(): boolean {
+    return !!this.form.value.id;
+  }
+
+  async save(): Promise<void> {
+    if (this.form.invalid || this.loading()) {
+      return;
+    }
+
+    this.loading.set(true);
+    const { id, password, username, email, firstName, lastName, role, confirmed, blocked } =
+      this.form.value;
+
+    const payload = {
+      username: username?.trim() ?? '',
+      email: email?.trim() ?? '',
+      firstName: firstName?.trim() || null,
+      lastName: lastName?.trim() || null,
+      role: role ? role : null,
+      confirmed: !!confirmed,
+      blocked: !!blocked,
+    } as const;
+
+    try {
+      const user = id
+        ? await this.usersService.update(id, {
+            ...payload,
+            password: password ? password : undefined,
+          })
+        : await this.usersService.create({
+            ...payload,
+            password: password ?? '',
+            provider: 'local',
+          });
+
+      this.snackBar.open('Usuario guardado correctamente', 'Cerrar', {
+        duration: 3000,
+      });
+      this.dialogRef.close(user);
+    } catch (error: any) {
+      const message = error?.error?.message ?? 'Error al guardar el usuario';
+      this.snackBar.open(message, 'Cerrar', { duration: 4000 });
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/features/users/user-list/user-list.component.html
+++ b/src/app/features/users/user-list/user-list.component.html
@@ -1,6 +1,10 @@
 <mat-toolbar color="primary" class="user-toolbar">
   <span class="title">Usuarios</span>
   <span class="spacer"></span>
+  <button mat-flat-button color="accent" (click)="openCreateDialog()">
+    <mat-icon>person_add</mat-icon>
+    Nuevo usuario
+  </button>
   <button mat-icon-button matTooltip="Actualizar" (click)="fetchUsers()" [disabled]="loading()">
     <mat-icon>refresh</mat-icon>
   </button>
@@ -63,6 +67,15 @@
             <span><strong>Creado:</strong> {{ user.createdAt | date:'short' }}</span>
             <span><strong>Actualizado:</strong> {{ user.updatedAt | date:'short' }}</span>
           </div>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef class="actions-header"></th>
+        <td mat-cell *matCellDef="let user" class="actions-cell">
+          <button mat-icon-button matTooltip="Editar" (click)="openEditDialog(user)">
+            <mat-icon>edit</mat-icon>
+          </button>
         </td>
       </ng-container>
 

--- a/src/app/features/users/user-list/user-list.component.scss
+++ b/src/app/features/users/user-list/user-list.component.scss
@@ -9,6 +9,13 @@
   .spacer {
     flex: 1 1 auto;
   }
+
+  button[mat-flat-button] {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-right: 0.5rem;
+  }
 }
 
 mat-card {
@@ -47,6 +54,15 @@ table {
   th {
     padding: 0.75rem;
   }
+}
+
+.actions-header {
+  width: 56px;
+}
+
+.actions-cell {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .status-cell {

--- a/src/app/models/users/user.model.ts
+++ b/src/app/models/users/user.model.ts
@@ -1,3 +1,8 @@
+export interface UserRoleApi {
+  id: number;
+  name?: string;
+}
+
 export interface UserApi {
   id: number;
   documentId: string;
@@ -8,6 +13,7 @@ export interface UserApi {
   email: string;
   firstName?: string | null;
   lastName?: string | null;
+  role?: number | UserRoleApi | null;
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
@@ -21,6 +27,10 @@ export interface User {
   blocked: boolean;
   username: string;
   email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  roleId?: number | null;
+  roleName?: string | null;
   fullName: string;
   createdAt: Date;
   updatedAt: Date;
@@ -35,6 +45,18 @@ export const mapUserApiToUser = (api: UserApi): User => ({
   blocked: api.blocked,
   username: api.username,
   email: api.email,
+  firstName: api.firstName ?? null,
+  lastName: api.lastName ?? null,
+  roleId:
+    typeof api.role === 'number'
+      ? api.role
+      : typeof api.role === 'object' && api.role
+        ? api.role.id
+        : null,
+  roleName:
+    typeof api.role === 'object' && api.role
+      ? api.role.name ?? null
+      : null,
   fullName: `${api.firstName ?? ''} ${api.lastName ?? ''}`.trim(),
   createdAt: new Date(api.createdAt),
   updatedAt: new Date(api.updatedAt),


### PR DESCRIPTION
## Summary
- add a reusable dialog form to create and edit users
- extend user models and service to map role data and call create/update endpoints
- refresh the user list UI with action buttons and dialog integration

## Testing
- npm run build *(fails: Google Fonts request returned 403 during asset inlining)*

------
https://chatgpt.com/codex/tasks/task_e_68f1caf0d53c8330be880908e19f44bf