### PR TITLE
Add profile page and integrate catalog with cart service

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { HomeComponent }     from './features/home/home.component';
 import { AdminComponent }    from './features/admin/admin.component';
 import { CatalogComponent } from './features/catalog/catalog.component';
 import { CartComponent } from './features/cart/cart.component';
+import { ProfileComponent } from './features/profile/profile.component';
 
 //ADMIN
 import { DashboardComponent } from './features/dashboard/dashboard.component';
@@ -37,6 +38,7 @@ export const routes: Routes = [
       { path: 'admin',    component: AdminComponent,  canActivate: [adminGuard] },
       { path: 'catalogo', component: CatalogComponent },
       { path: 'carrito', component: CartComponent },
+      { path: 'perfil', component: ProfileComponent, canActivate: [authGuard] },
 
       { path: 'dashboard', component: DashboardComponent },
       {

--- a/src/app/core/services/inventory.service.ts
+++ b/src/app/core/services/inventory.service.ts
@@ -44,7 +44,7 @@ export class InventoryService {
       .set('sort', 'createdAt:desc');
 
     const res = await firstValueFrom(
-      this.http.get<ProductsResponse>(`${this.API}/products`)
+      this.http.get<ProductsResponse>(`${this.API}/products`, { params })
     );
 
     const rows = (res.data ?? []).map(mapApiToProduct);

--- a/src/app/core/services/users.service.ts
+++ b/src/app/core/services/users.service.ts
@@ -67,4 +67,17 @@ export class UsersService {
 
     return mapUserApiToUser(res);
   }
+
+  async findById(id: number | string): Promise<User> {
+    const res = await firstValueFrom(
+      this.http.get<UserApi | { data: UserApi }>(`${this.API}/users/${id}`)
+    );
+
+    const item = (res as any)?.data ?? res;
+    if (!item) {
+      throw new Error('Usuario no encontrado');
+    }
+
+    return mapUserApiToUser(item as UserApi);
+  }
 }

--- a/src/app/features/cart/cart.service.ts
+++ b/src/app/features/cart/cart.service.ts
@@ -19,30 +19,124 @@ export interface ShippingOption {
   cost: number;
 }
 
+export interface AddToCartPayload {
+  id: string;
+  name: string;
+  brand?: string | null;
+  price: number;
+  image?: string | null;
+  quantity?: number;
+  stock?: number;
+  compatibility?: string | null;
+}
+
+const DEFAULT_IMAGE = 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=800&q=80';
+const DEFAULT_COMPATIBILITY = 'Compatible con la mayoría de modelos';
+const DEFAULT_STOCK = 10;
+
 @Injectable({
   providedIn: 'root',
 })
 export class CartService {
+  private readonly CART_KEY = 'app:cart-items';
+  private readonly SHIPPING_KEY = 'app:cart-shipping';
+  private readonly COUPON_KEY = 'app:cart-coupon';
+
   private cartItems$ = new BehaviorSubject<CartItem[]>([]);
   private selectedShipping$ = new BehaviorSubject<ShippingOption | null>(null);
   private appliedCoupon$ = new BehaviorSubject<'AHORRA10' | null>(null);
 
-  constructor() {}
+  constructor() {
+    this.restoreState();
+  }
+
+  private get storage(): Storage | null {
+    try {
+      return typeof localStorage === 'undefined' ? null : localStorage;
+    } catch {
+      return null;
+    }
+  }
+
+  private restoreState(): void {
+    const storage = this.storage;
+    if (!storage) {
+      return;
+    }
+
+    const rawItems = storage.getItem(this.CART_KEY);
+    if (rawItems) {
+      try {
+        const parsed = JSON.parse(rawItems) as CartItem[];
+        if (Array.isArray(parsed)) {
+          this.cartItems$.next(parsed);
+        }
+      } catch {
+        storage.removeItem(this.CART_KEY);
+      }
+    }
+
+    const rawShipping = storage.getItem(this.SHIPPING_KEY);
+    if (rawShipping) {
+      try {
+        const parsed = JSON.parse(rawShipping) as ShippingOption | null;
+        this.selectedShipping$.next(parsed ?? null);
+      } catch {
+        storage.removeItem(this.SHIPPING_KEY);
+      }
+    }
+
+    const rawCoupon = storage.getItem(this.COUPON_KEY);
+    if (rawCoupon) {
+      try {
+        const parsed = JSON.parse(rawCoupon) as 'AHORRA10' | null;
+        this.appliedCoupon$.next(parsed ?? null);
+      } catch {
+        storage.removeItem(this.COUPON_KEY);
+      }
+    }
+  }
+
+  private persistCartItems(items: CartItem[]): void {
+    const storage = this.storage;
+    if (!storage) return;
+    storage.setItem(this.CART_KEY, JSON.stringify(items));
+  }
+
+  private persistShipping(shipping: ShippingOption | null): void {
+    const storage = this.storage;
+    if (!storage) return;
+    if (shipping) storage.setItem(this.SHIPPING_KEY, JSON.stringify(shipping));
+    else storage.removeItem(this.SHIPPING_KEY);
+  }
+
+  private persistCoupon(coupon: 'AHORRA10' | null): void {
+    const storage = this.storage;
+    if (!storage) return;
+    if (coupon) storage.setItem(this.COUPON_KEY, JSON.stringify(coupon));
+    else storage.removeItem(this.COUPON_KEY);
+  }
 
   getCartItems() {
     return this.cartItems$.asObservable();
   }
 
+  getCartItemsSnapshot(): CartItem[] {
+    return this.cartItems$.value;
+  }
+
   setCartItems(items: CartItem[]) {
     this.cartItems$.next(items);
+    this.persistCartItems(items);
   }
 
   getSelectedShipping() {
     return this.selectedShipping$.asObservable();
   }
 
-  setSelectedShipping(shipping: ShippingOption) {
+  setSelectedShipping(shipping: ShippingOption | null) {
     this.selectedShipping$.next(shipping);
+    this.persistShipping(shipping);
   }
 
   getAppliedCoupon() {
@@ -51,6 +145,61 @@ export class CartService {
 
   setAppliedCoupon(coupon: 'AHORRA10' | null) {
     this.appliedCoupon$.next(coupon);
+    this.persistCoupon(coupon);
+  }
+
+  addItem(payload: AddToCartPayload): void {
+    const items = [...this.cartItems$.value];
+    const index = items.findIndex((item) => item.id === payload.id);
+    const quantityToAdd = Math.max(payload.quantity ?? 1, 1);
+
+    if (index >= 0) {
+      const current = items[index];
+      const maxStock = payload.stock ?? current.stock ?? DEFAULT_STOCK;
+      const newQuantity = Math.min(current.quantity + quantityToAdd, maxStock);
+      items[index] = {
+        ...current,
+        quantity: newQuantity,
+        stock: maxStock,
+      };
+    } else {
+      const stock = payload.stock ?? DEFAULT_STOCK;
+      items.push({
+        id: payload.id,
+        name: payload.name,
+        brand: payload.brand ?? 'Genérico',
+        price: payload.price,
+        quantity: Math.min(quantityToAdd, stock),
+        stock,
+        image: payload.image ?? DEFAULT_IMAGE,
+        compatibility: payload.compatibility ?? DEFAULT_COMPATIBILITY,
+      });
+    }
+
+    this.setCartItems(items);
+  }
+
+  changeItemQuantity(itemId: string, delta: number): void {
+    if (!delta) return;
+
+    const items = this.cartItems$.value.map((item) => {
+      if (item.id !== itemId) return item;
+      const stock = item.stock ?? DEFAULT_STOCK;
+      const nextQuantity = Math.min(Math.max(item.quantity + delta, 1), stock);
+      return { ...item, quantity: nextQuantity };
+    });
+
+    this.setCartItems(items);
+  }
+
+  removeItem(itemId: string): void {
+    const items = this.cartItems$.value.filter((item) => item.id !== itemId);
+    this.setCartItems(items);
+  }
+
+  clearCart(): void {
+    this.setCartItems([]);
+    this.setAppliedCoupon(null);
   }
 
   getCurrentCartState() {

--- a/src/app/features/catalog/catalog.component.html
+++ b/src/app/features/catalog/catalog.component.html
@@ -94,10 +94,10 @@
 
             <!-- Chips seleccionables -->
             <mat-chip-listbox multiple class="flex flex-wrap gap-2">
-              <mat-chip-option
+            <mat-chip-option
                 *ngFor="let b of filteredBrands"
                 class="rounded-full"
-                [selected]="filters.controls.brands.value.includes(b)"
+                [selected]="(filters.controls.brands.value ?? []).includes(b)"
                 (selectionChange)="onBrandChip(b, $event.selected)"
               >
                 {{ b }}
@@ -147,6 +147,14 @@
       <div class="text-sm text-gray-500">Mostrando {{ total }} productos</div>
     </div>
 
+    <div *ngIf="error" class="mb-4 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+      <mat-icon>error_outline</mat-icon>
+      <span>{{ error }}</span>
+      <button mat-button color="primary" type="button" class="ml-auto" (click)="loadProducts()">
+        Reintentar
+      </button>
+    </div>
+
     <!-- Grid de cards -->
     <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
       <!-- Skeletons -->
@@ -161,20 +169,35 @@
 
       <!-- Productos -->
       <ng-template #productsTpl>
-        <mat-card *ngFor="let p of paged" class="rounded-xl overflow-hidden">
-          <img mat-card-image [src]="p.image" [alt]="p.name" class="h-36 object-cover" />
-          <mat-card-content>
-            <div class="mt-2 font-semibold">{{ p.name }}</div>
-            <div class="text-sm text-gray-500">{{ p.description }}</div>
-            <div class="mt-2 font-bold">
-              {{ p.price | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}
-            </div>
-          </mat-card-content>
-          <mat-card-actions class="p-3 pt-0 flex items-center justify-between">
-            <span class="text-xs text-gray-500">{{ p.brand }}</span>
-            <button mat-flat-button color="primary" (click)="addToCart(p)">Agregar</button>
-          </mat-card-actions>
-        </mat-card>
+        <ng-container *ngIf="paged.length; else emptyResults">
+          <mat-card *ngFor="let p of paged" class="overflow-hidden rounded-xl">
+            <img mat-card-image [src]="p.image" [alt]="p.name" class="h-36 w-full object-cover" />
+            <mat-card-content>
+              <div class="mt-2 font-semibold text-gray-900">{{ p.name }}</div>
+              <div class="text-xs uppercase tracking-wide text-blue-600">{{ p.brand }}</div>
+              <div class="mt-2 h-14 overflow-hidden text-sm text-gray-500">{{ p.description }}</div>
+              <div class="mt-3 flex items-center justify-between text-sm">
+                <span [class.text-green-600]="p.inStock" [class.text-red-500]="!p.inStock">
+                  <mat-icon class="align-middle text-base">{{ p.inStock ? 'inventory_2' : 'highlight_off' }}</mat-icon>
+                  {{ p.inStock ? (p.stock + ' disponibles') : 'Sin stock' }}
+                </span>
+                <span class="font-bold text-gray-900">
+                  {{ p.price | currency : 'GTQ' : 'symbol-narrow' : '1.2-2' }}
+                </span>
+              </div>
+            </mat-card-content>
+            <mat-card-actions class="flex items-center justify-end gap-2 p-3 pt-0">
+              <button
+                mat-flat-button
+                color="primary"
+                (click)="addToCart(p)"
+                [disabled]="!p.inStock"
+              >
+                {{ p.inStock ? 'Agregar' : 'Sin stock' }}
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        </ng-container>
       </ng-template>
     </div>
 
@@ -191,3 +214,14 @@
     </div>
   </section>
 </div>
+
+<ng-template #emptyResults>
+  <mat-card class="col-span-full border border-dashed border-gray-200 bg-gray-50 text-center">
+    <mat-card-content class="flex flex-col items-center gap-2 py-10">
+      <mat-icon>search_off</mat-icon>
+      <p class="text-base font-semibold text-gray-700">No encontramos productos con esos filtros.</p>
+      <p class="text-sm text-gray-500">Prueba ajustando la búsqueda o limpiando los filtros aplicados.</p>
+      <button mat-stroked-button color="primary" type="button" (click)="clearAll()">Limpiar filtros</button>
+    </mat-card-content>
+  </mat-card>
+</ng-template>

--- a/src/app/features/catalog/catalog.component.ts
+++ b/src/app/features/catalog/catalog.component.ts
@@ -179,7 +179,7 @@ export class CatalogComponent implements OnInit {
     const category = (product.categoria || 'otros').trim().toLowerCase();
     const description = product.description || 'Sin descripción disponible.';
     const price = Number.isFinite(product.precio) ? Number(product.precio) : 0;
-    const stock = product.stock && product.stock > 0 ? product.stock : 10;
+    const stock = product.stock && product.stock > 0 ? product.stock : this.getFallbackStock(id);
     const inStock = product.estado !== 'inactivo';
     const image = product.imagenUrl || this.getPlaceholderImage(id);
 
@@ -203,6 +203,15 @@ export class CatalogComponent implements OnInit {
     }
     const index = hash % PLACEHOLDER_IMAGES.length;
     return PLACEHOLDER_IMAGES[index];
+  }
+
+  private getFallbackStock(seed: string): number {
+    let hash = 5381;
+    for (let i = 0; i < seed.length; i += 1) {
+      hash = (hash * 33) ^ seed.charCodeAt(i);
+    }
+    const normalized = Math.abs(hash) % 20; // 0 - 19
+    return normalized + 5; // 5 - 24 unidades
   }
 
   private refreshMetadata(): void {

--- a/src/app/features/catalog/catalog.component.ts
+++ b/src/app/features/catalog/catalog.component.ts
@@ -181,8 +181,10 @@ export class CatalogComponent implements OnInit {
     const category = (product.categoria || 'otros').trim().toLowerCase();
     const description = product.description || 'Sin descripción disponible.';
     const price = Number.isFinite(product.precio) ? Number(product.precio) : 0;
-    const stock = product.stock && product.stock > 0 ? product.stock : this.getFallbackStock(id);
-    const inStock = (product.estado ?? 'activo') !== 'inactivo' && stock > 0;
+    const hasBackendStock = typeof product.stock === 'number' && product.stock > 0;
+    const stock = hasBackendStock ? product.stock : this.getFallbackStock(id);
+    const status = hasBackendStock ? product.estado ?? 'activo' : 'activo';
+    const inStock = status !== 'inactivo' && stock > 0;
     const image = product.imagenUrl || this.getPlaceholderImage(id);
 
     return {

--- a/src/app/features/profile/profile.component.html
+++ b/src/app/features/profile/profile.component.html
@@ -1,0 +1,87 @@
+<div class="profile-page">
+  <section class="profile-container">
+    <header class="profile-header">
+      <h1>Mi perfil</h1>
+      <p>Consulta la información asociada a tu cuenta y mantenla siempre actualizada.</p>
+    </header>
+
+    <div *ngIf="loading" class="profile-loading" aria-live="polite">
+      <mat-progress-spinner mode="indeterminate" diameter="48"></mat-progress-spinner>
+      <p>Cargando información del perfil...</p>
+    </div>
+
+    <ng-container *ngIf="!loading">
+      <ng-container *ngIf="user; else errorState">
+        <mat-card class="profile-card">
+          <mat-card-header>
+            <div mat-card-avatar class="profile-avatar">{{ displayInitials }}</div>
+            <mat-card-title>{{ displayName }}</mat-card-title>
+            <mat-card-subtitle>{{ user.email }}</mat-card-subtitle>
+          </mat-card-header>
+
+          <mat-card-content>
+            <dl class="profile-details">
+              <div>
+                <dt>Usuario</dt>
+                <dd>{{ user.username || 'Sin usuario' }}</dd>
+              </div>
+              <div>
+                <dt>Nombre completo</dt>
+                <dd>{{ user.fullName || 'Sin información' }}</dd>
+              </div>
+              <div>
+                <dt>Rol</dt>
+                <dd>{{ user.roleName || ('#' + user.roleId) || 'No asignado' }}</dd>
+              </div>
+              <div>
+                <dt>Estado</dt>
+                <dd>
+                  <span
+                    class="status-pill"
+                    [class.status-pill--active]="user.confirmed && !user.blocked"
+                    [class.status-pill--blocked]="user.blocked"
+                  >
+                    <mat-icon>{{ user.blocked ? 'block' : user.confirmed ? 'verified_user' : 'hourglass_top' }}</mat-icon>
+                    {{ accountStatusLabel }}
+                  </span>
+                </dd>
+              </div>
+              <div>
+                <dt>Fecha de registro</dt>
+                <dd>{{ user.createdAt | date : 'medium' }}</dd>
+              </div>
+              <div>
+                <dt>Última actualización</dt>
+                <dd>{{ user.updatedAt | date : 'medium' }}</dd>
+              </div>
+            </dl>
+          </mat-card-content>
+
+          <mat-card-actions class="profile-actions">
+            <button mat-flat-button color="primary" type="button" (click)="loadProfile()">
+              <mat-icon>refresh</mat-icon>
+              Actualizar datos
+            </button>
+            <a mat-stroked-button color="primary" routerLink="/catalogo">
+              <mat-icon>storefront</mat-icon>
+              Ir al catálogo
+            </a>
+          </mat-card-actions>
+        </mat-card>
+      </ng-container>
+    </ng-container>
+
+    <ng-template #errorState>
+      <mat-card class="profile-error">
+        <mat-card-content>
+          <mat-icon>sentiment_dissatisfied</mat-icon>
+          <p>{{ error || 'No fue posible recuperar tu información de perfil.' }}</p>
+          <div class="error-actions">
+            <button mat-flat-button color="primary" type="button" (click)="loadProfile()">Reintentar</button>
+            <a mat-button routerLink="/login">Iniciar sesión</a>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </ng-template>
+  </section>
+</div>

--- a/src/app/features/profile/profile.component.scss
+++ b/src/app/features/profile/profile.component.scss
@@ -1,0 +1,165 @@
+.profile-page {
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.profile-container {
+  width: min(900px, 100%);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.profile-header {
+  text-align: center;
+
+  h1 {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+    color: #0f172a;
+  }
+
+  p {
+    color: #475569;
+    margin: 0;
+  }
+}
+
+.profile-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 0;
+
+  p {
+    color: #475569;
+    font-weight: 500;
+  }
+}
+
+.profile-card {
+  border-radius: 1.5rem;
+  overflow: hidden;
+
+  mat-card-header {
+    align-items: center;
+    padding-bottom: 0.5rem;
+  }
+}
+
+.profile-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.125rem;
+  text-transform: uppercase;
+}
+
+.profile-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 1.5rem;
+
+  dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #64748b;
+    margin-bottom: 0.35rem;
+  }
+
+  dd {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #0f172a;
+    font-weight: 500;
+  }
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 9999px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background-color: #e2e8f0;
+  color: #1e293b;
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  &--active {
+    background-color: #dcfce7;
+    color: #166534;
+  }
+
+  &--blocked {
+    background-color: #fee2e2;
+    color: #b91c1c;
+  }
+}
+
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem 1.5rem;
+
+  button, a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+.profile-error {
+  border: 1px dashed #cbd5f5;
+  background: #f8fafc;
+  text-align: center;
+  padding: 2rem;
+  border-radius: 1.5rem;
+
+  mat-icon {
+    color: #94a3b8;
+    font-size: 2rem;
+    width: 2rem;
+    height: 2rem;
+  }
+
+  p {
+    margin: 1rem 0;
+    color: #475569;
+    font-weight: 500;
+  }
+}
+
+.error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .profile-actions {
+    flex-direction: column;
+    align-items: stretch;
+
+    button, a {
+      justify-content: center;
+    }
+  }
+}

--- a/src/app/features/profile/profile.component.ts
+++ b/src/app/features/profile/profile.component.ts
@@ -1,0 +1,87 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { UsersService } from '../../core/services/users.service';
+import { AuthService } from '../../core/services/auth.service';
+import { User } from '../../models/users/user.model';
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './profile.component.html',
+  styleUrls: ['./profile.component.scss'],
+})
+export class ProfileComponent implements OnInit {
+  loading = false;
+  error: string | null = null;
+  user: User | null = null;
+
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+  ) {}
+
+  ngOnInit(): void {
+    void this.loadProfile();
+  }
+
+  async loadProfile(): Promise<void> {
+    const userId = this.authService.currentUserId;
+    if (!userId) {
+      this.user = null;
+      this.error = 'No se encontró información de la sesión. Inicia sesión nuevamente.';
+      this.loading = false;
+      return;
+    }
+
+    this.loading = true;
+    this.error = null;
+
+    try {
+      this.user = await this.usersService.findById(userId);
+    } catch (err) {
+      console.error('Error al cargar el perfil', err);
+      this.user = null;
+      this.error = 'No fue posible cargar tu perfil. Intenta nuevamente en unos momentos.';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  get displayName(): string {
+    if (!this.user) {
+      return 'Usuario';
+    }
+    return this.user.fullName || this.user.username || this.user.email || 'Usuario';
+  }
+
+  get displayInitials(): string {
+    const name = this.displayName.trim();
+    if (!name) {
+      return 'U';
+    }
+    const parts = name.split(/\s+/).slice(0, 2);
+    const initials = parts.map((part) => part.charAt(0).toUpperCase()).join('');
+    return initials || name.charAt(0).toUpperCase() || 'U';
+  }
+
+  get accountStatusLabel(): string {
+    if (!this.user) return '';
+    if (this.user.blocked) return 'Bloqueado';
+    if (this.user.confirmed) return 'Confirmado';
+    return 'Pendiente de confirmación';
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone profile view that loads the current user details through the users service and protect it behind the auth guard
- fetch catalog products from the inventory service, surface error/empty states, and wire the add button to the shared cart service with feedback
- persist cart contents, shipping, and coupons in local storage so the catalog, cart view, and checkout stay in sync
- store the authenticated user metadata during login so the profile component can request the correct record

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68fad97d72c48330ab46499a87d3045d