### PR TITLE
Integrate real inventory endpoints

### DIFF
--- a/src/app/core/services/inventory.service.ts
+++ b/src/app/core/services/inventory.service.ts
@@ -161,6 +161,25 @@ export class InventoryService {
     );
   }
 
+  async adjustInventoryRecord(
+    inventoryId: number | string,
+    movement: { quantity: number; action: 'add' | 'remove' }
+  ): Promise<void> {
+    const quantity = Math.max(0, Math.trunc(movement.quantity ?? 0));
+    const action = movement.action === 'remove' ? 'remove' : 'add';
+
+    if (!quantity) {
+      return;
+    }
+
+    await firstValueFrom(
+      this.http.patch(`${this.API}/bulkloadinventory/update/${inventoryId}`, {
+        quantity,
+        action,
+      })
+    );
+  }
+
   async create(p: {
     sku: string;
     nombre: string;

--- a/src/app/core/services/inventory.service.ts
+++ b/src/app/core/services/inventory.service.ts
@@ -3,7 +3,28 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { Product, ProductApi, mapApiToProduct } from '../../models/inventory/inventory.models';
+import {
+  Product,
+  ProductApi,
+  determineProductStatus,
+  mapApiToProduct,
+} from '../../models/inventory/inventory.models';
+
+type InventoryItemApi = {
+  id: number;
+  documentId?: string;
+  quantity?: number;
+  stock_status?: string | null;
+  last_updated?: string | null;
+  vendor?: string | null;
+  product?: ProductApi | null;
+};
+
+type InventoryListResponse = {
+  message?: string;
+  total?: number;
+  data?: InventoryItemApi[];
+};
 
 type ProductsResponse = {
   data: ProductApi[];
@@ -48,14 +69,96 @@ export class InventoryService {
       // 👇 IMPORTANTE: trae la media para poder construir imagenUrl
       .set('populate', 'referenceImage');
 
-    const res = await firstValueFrom(
-      this.http.get<ProductsResponse>(`${this.API}/products`, { params })
+    const [productsRes, inventoryRes] = await Promise.all([
+      firstValueFrom(this.http.get<ProductsResponse>(`${this.API}/products`, { params })),
+      this.fetchInventorySnapshot(),
+    ]);
+
+    const inventoryByProduct = new Map<number, InventoryItemApi>();
+    for (const item of inventoryRes.data ?? []) {
+      const productId = item?.product?.id;
+      if (typeof productId === 'number') {
+        inventoryByProduct.set(productId, item);
+      }
+    }
+
+    const rows = (productsRes.data ?? []).map((apiProduct) => {
+      const base = mapApiToProduct(apiProduct);
+      const productId = Number(base.id);
+      const inventory = Number.isFinite(productId) ? inventoryByProduct.get(productId) : undefined;
+
+      if (!inventory) {
+        return base;
+      }
+
+      const quantity = Number(inventory.quantity ?? 0);
+      const minimo = base.minimo ?? 0;
+      const status = inventory.stock_status ?? null;
+      const estado = this.mapStockStatusToProductStatus(status, quantity, minimo);
+
+      return {
+        ...base,
+        stock: Number.isFinite(quantity) ? quantity : base.stock,
+        minimo,
+        estado,
+        proveedor: base.proveedor ?? inventory.vendor ?? null,
+        inventoryId: inventory.id,
+        inventoryDocumentId: inventory.documentId ?? null,
+        stockStatus: status,
+        lastUpdated: inventory.last_updated ?? null,
+      };
+    });
+
+    const meta = productsRes.meta?.pagination ?? { page, pageSize, pageCount: 1, total: rows.length };
+
+    return {
+      rows,
+      total: meta.total,
+      page: meta.page,
+      pageSize: meta.pageSize,
+      pageCount: meta.pageCount,
+    };
+  }
+
+  private fetchInventorySnapshot(): Promise<InventoryListResponse> {
+    return firstValueFrom(
+      this.http.get<InventoryListResponse>(`${this.API}/bulkloadinventory/all`)
+    ).catch(() => ({ data: [], total: 0 } as InventoryListResponse));
+  }
+
+  private mapStockStatusToProductStatus(
+    status: string | null,
+    quantity: number,
+    minimo: number
+  ): Product['estado'] {
+    switch (status) {
+      case 'in_stock':
+        return 'activo';
+      case 'low_stock':
+        return 'bajo-stock';
+      case 'out_of_stock':
+      case 'no_stock':
+        return 'inactivo';
+      default:
+        return determineProductStatus(quantity, minimo);
+    }
+  }
+
+  async createInventoryRecord(entry: {
+    productId: number;
+    quantity: number;
+    vendor?: string | null;
+  }): Promise<void> {
+    const quantity = Math.max(0, Math.trunc(entry.quantity ?? 0));
+    const vendor = (entry.vendor ?? '').trim();
+
+    await firstValueFrom(
+      this.http.post(`${this.API}/bulkloadinventory/createOne`, {
+        product: entry.productId,
+        quantity,
+        vendor,
+      })
     );
-
-    const rows = (res.data ?? []).map(mapApiToProduct);
-    const meta = res.meta?.pagination ?? { page, pageSize, pageCount: 1, total: rows.length };
-
-    return { rows, total: meta.total, page: meta.page, pageSize: meta.pageSize, pageCount: meta.pageCount };
   }
 
   async create(p: {

--- a/src/app/features/inventory/inventory-adjust-dialog/inventory-adjust-dialog.component.html
+++ b/src/app/features/inventory/inventory-adjust-dialog/inventory-adjust-dialog.component.html
@@ -1,0 +1,35 @@
+<h2 mat-dialog-title class="title">
+  <mat-icon>inventory</mat-icon>
+  <span>Ajustar inventario</span>
+</h2>
+
+<mat-dialog-content class="content">
+  <div class="product-summary">
+    <div class="name">{{ product.nombre }}</div>
+    <div class="meta">SKU {{ product.sku }} • {{ product.proveedor || 'Sin proveedor' }}</div>
+    <div class="stock">Stock actual: {{ product.stock }} unidades</div>
+  </div>
+
+  <form [formGroup]="form" (ngSubmit)="submit()" id="adjustForm">
+    <mat-form-field appearance="fill" class="field">
+      <mat-label>Acción</mat-label>
+      <mat-select formControlName="action">
+        <mat-option value="add">Agregar unidades</mat-option>
+        <mat-option value="remove" [disabled]="!hasInventory">Retirar unidades</mat-option>
+      </mat-select>
+      <mat-hint *ngIf="!hasInventory">Se creará un registro de inventario.</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="field">
+      <mat-label>Cantidad</mat-label>
+      <input matInput type="number" formControlName="quantity" min="1" step="1" />
+      <mat-error *ngIf="form.get('quantity')?.hasError('min')">Debe ser mayor que cero</mat-error>
+      <mat-error *ngIf="form.get('quantity')?.hasError('required')">Requerido</mat-error>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="actions">
+  <button mat-button type="button" (click)="cancel()">Cancelar</button>
+  <button mat-flat-button color="primary" type="submit" form="adjustForm">Guardar</button>
+</mat-dialog-actions>

--- a/src/app/features/inventory/inventory-adjust-dialog/inventory-adjust-dialog.component.scss
+++ b/src/app/features/inventory/inventory-adjust-dialog/inventory-adjust-dialog.component.scss
@@ -1,0 +1,41 @@
+.title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.product-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 0;
+  font-size: 14px;
+}
+
+.product-summary .name {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.product-summary .meta {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.product-summary .stock {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.field {
+  width: 100%;
+}
+
+.actions {
+  padding: 16px 0 0;
+}

--- a/src/app/features/inventory/inventory-adjust-dialog/inventory-adjust-dialog.component.ts
+++ b/src/app/features/inventory/inventory-adjust-dialog/inventory-adjust-dialog.component.ts
@@ -1,0 +1,114 @@
+// src/app/features/inventory/inventory-adjust-dialog/inventory-adjust-dialog.component.ts
+import { Component, Inject, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { Product } from '../../../models/inventory/inventory.models';
+import { InventoryService } from '../../../core/services/inventory.service';
+
+type InventoryAdjustDialogData = {
+  product: Product;
+  action?: 'add' | 'remove';
+};
+
+@Component({
+  selector: 'app-inventory-adjust-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatIconModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './inventory-adjust-dialog.component.html',
+  styleUrls: ['./inventory-adjust-dialog.component.scss'],
+})
+export class InventoryAdjustDialogComponent {
+  private fb = inject(FormBuilder);
+  private ref = inject(MatDialogRef<InventoryAdjustDialogComponent>);
+  private snack = inject(MatSnackBar);
+  private inv = inject(InventoryService);
+
+  form = this.fb.group({
+    action: ['add' as 'add' | 'remove'],
+    quantity: [1, [Validators.required, Validators.min(1)]],
+  });
+
+  product: Product;
+  hasInventory: boolean;
+
+  constructor(@Inject(MAT_DIALOG_DATA) data: InventoryAdjustDialogData) {
+    this.product = data.product;
+    this.hasInventory = data.product.inventoryId != null;
+
+    if (data.action) {
+      this.form.patchValue({ action: data.action });
+    }
+
+    if (!this.hasInventory) {
+      // Si no hay inventario previo solo permitimos sumar
+      this.form.get('action')?.setValue('add');
+      this.form.get('action')?.disable();
+    }
+  }
+
+  async submit() {
+    if (this.form.invalid) return;
+
+    const quantity = Number(this.form.value.quantity ?? 0);
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      this.snack.open('Ingresa una cantidad válida', 'Cerrar', { duration: 2500 });
+      return;
+    }
+
+    const actionControl = this.form.get('action');
+    const action = (actionControl?.value ?? 'add') === 'remove' ? 'remove' : 'add';
+
+    try {
+      if (this.hasInventory) {
+        await this.inv.adjustInventoryRecord(this.product.inventoryId!, {
+          quantity,
+          action,
+        });
+      } else {
+        if (action !== 'add') {
+          throw new Error('No existe inventario para retirar.');
+        }
+
+        const productId = Number(this.product.id);
+        if (!Number.isFinite(productId)) {
+          throw new Error('No fue posible determinar el producto.');
+        }
+
+        await this.inv.createInventoryRecord({
+          productId,
+          quantity,
+          vendor: this.product.proveedor ?? null,
+        });
+      }
+
+      this.snack.open('Inventario actualizado', 'OK', { duration: 2000 });
+      this.ref.close(true);
+    } catch (e: any) {
+      this.snack.open(e?.error?.message ?? e?.message ?? 'No se pudo actualizar', 'Cerrar', {
+        duration: 3000,
+      });
+    }
+  }
+
+  cancel() {
+    this.ref.close(false);
+  }
+}

--- a/src/app/features/inventory/inventory-list/inventory-list.component.html
+++ b/src/app/features/inventory/inventory-list/inventory-list.component.html
@@ -190,6 +190,12 @@
               <button mat-menu-item (click)="openEdit(e)">
                 <mat-icon>edit</mat-icon><span>Editar</span>
               </button>
+              <button mat-menu-item (click)="openAdjust(e, 'add')">
+                <mat-icon>add_shopping_cart</mat-icon><span>Agregar inventario</span>
+              </button>
+              <button mat-menu-item (click)="openAdjust(e, 'remove')" [disabled]="!e.inventoryId">
+                <mat-icon>remove_shopping_cart</mat-icon><span>Retirar inventario</span>
+              </button>
               <button mat-menu-item (click)="openMoves(e)">
                 <mat-icon>history</mat-icon><span>Movimientos</span>
               </button>

--- a/src/app/features/inventory/inventory-list/inventory-list.component.ts
+++ b/src/app/features/inventory/inventory-list/inventory-list.component.ts
@@ -27,6 +27,7 @@ import { InventoryService } from '../../../core/services/inventory.service';
 import { Product } from '../../../models/inventory/inventory.models';
 import { ProductFormDialogComponent } from '../product-form-dialog/product-form-dialog.component';
 import { StockMovementsDrawerComponent } from '../stock-movements-drawer/stock-movements-drawer.component';
+import { InventoryAdjustDialogComponent } from '../inventory-adjust-dialog/inventory-adjust-dialog.component';
 
 @Component({
   selector: 'app-inventory-list',
@@ -53,6 +54,7 @@ import { StockMovementsDrawerComponent } from '../stock-movements-drawer/stock-m
     MatSidenavModule,
     MatDividerModule,
     MatProgressBarModule,
+    InventoryAdjustDialogComponent,
   ],
   templateUrl: './inventory-list.component.html',
   styleUrls: ['./inventory-list.component.scss'],
@@ -190,6 +192,17 @@ export class InventoryListComponent implements OnInit {
     const ref = this.dialog.open(ProductFormDialogComponent, { width: '720px', data: p });
     ref.afterClosed().subscribe((saved) => {
       if (saved) this.fetch();
+    });
+  }
+
+  openAdjust(p: Product, action: 'add' | 'remove' = 'add') {
+    const ref = this.dialog.open(InventoryAdjustDialogComponent, {
+      width: '420px',
+      data: { product: p, action },
+    });
+
+    ref.afterClosed().subscribe((changed) => {
+      if (changed) this.fetch();
     });
   }
 

--- a/src/app/features/inventory/product-form-dialog/product-form-dialog.component.html
+++ b/src/app/features/inventory/product-form-dialog/product-form-dialog.component.html
@@ -49,6 +49,32 @@
       <mat-error *ngIf="form.get('stock')?.hasError('min')">No puede ser negativo</mat-error>
     </mat-form-field>
 
+    <ng-container *ngIf="form.value.id">
+      <mat-form-field appearance="fill">
+        <mat-label>Movimiento de inventario</mat-label>
+        <mat-select formControlName="adjustmentAction">
+          <mat-option value="add">Agregar unidades</mat-option>
+          <mat-option value="remove">Retirar unidades</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Cantidad a mover</mat-label>
+        <input
+          matInput
+          type="number"
+          min="0"
+          step="1"
+          formControlName="adjustmentQuantity"
+          placeholder="0"
+        />
+        <mat-hint>Solo se aplicará si es mayor a 0.</mat-hint>
+        <mat-error *ngIf="form.get('adjustmentQuantity')?.hasError('min')">
+          No puede ser negativo
+        </mat-error>
+      </mat-form-field>
+    </ng-container>
+
     <mat-form-field appearance="fill">
       <mat-label>Descripción</mat-label>
       <textarea matInput rows="3" formControlName="description" placeholder="Opcional"></textarea>

--- a/src/app/features/inventory/product-form-dialog/product-form-dialog.component.html
+++ b/src/app/features/inventory/product-form-dialog/product-form-dialog.component.html
@@ -35,6 +35,21 @@
     </mat-form-field>
 
     <mat-form-field appearance="fill">
+      <mat-label>Cantidad inicial (inventario)</mat-label>
+      <input
+        matInput
+        type="number"
+        min="0"
+        step="1"
+        formControlName="stock"
+        placeholder="0"
+        [disabled]="form.value.id"
+      />
+      <mat-hint *ngIf="form.value.id">Actualiza el stock desde los movimientos de inventario.</mat-hint>
+      <mat-error *ngIf="form.get('stock')?.hasError('min')">No puede ser negativo</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
       <mat-label>Descripción</mat-label>
       <textarea matInput rows="3" formControlName="description" placeholder="Opcional"></textarea>
     </mat-form-field>

--- a/src/app/features/inventory/product-form-dialog/product-form-dialog.component.html
+++ b/src/app/features/inventory/product-form-dialog/product-form-dialog.component.html
@@ -54,8 +54,11 @@
         <mat-label>Movimiento de inventario</mat-label>
         <mat-select formControlName="adjustmentAction">
           <mat-option value="add">Agregar unidades</mat-option>
-          <mat-option value="remove">Retirar unidades</mat-option>
+          <mat-option value="remove" [disabled]="!form.value.inventoryId">Retirar unidades</mat-option>
         </mat-select>
+        <mat-hint *ngIf="!form.value.inventoryId">
+          Se creará un registro de inventario al agregar unidades.
+        </mat-hint>
       </mat-form-field>
 
       <mat-form-field appearance="fill">

--- a/src/app/features/inventory/product-form-dialog/product-form-dialog.component.ts
+++ b/src/app/features/inventory/product-form-dialog/product-form-dialog.component.ts
@@ -93,11 +93,25 @@ export class ProductFormDialogComponent {
         const quantity = Number(v.adjustmentQuantity ?? 0);
         const action = v.adjustmentAction === 'remove' ? 'remove' : 'add';
 
-        if (inventoryId != null && Number.isFinite(quantity) && quantity > 0) {
-          await this.inv.adjustInventoryRecord(inventoryId, {
-            quantity,
-            action,
-          });
+        if (Number.isFinite(quantity) && quantity > 0) {
+          if (inventoryId != null) {
+            await this.inv.adjustInventoryRecord(inventoryId, {
+              quantity,
+              action,
+            });
+          } else if (action === 'add') {
+            const productId = Number(result.id ?? v.id ?? this.data?.id);
+
+            if (!Number.isFinite(productId)) {
+              throw new Error('No fue posible obtener el identificador del producto.');
+            }
+
+            await this.inv.createInventoryRecord({
+              productId,
+              quantity,
+              vendor: v.proveedor ?? this.data?.proveedor ?? null,
+            });
+          }
         }
       }
 

--- a/src/app/features/inventory/product-form-dialog/product-form-dialog.component.ts
+++ b/src/app/features/inventory/product-form-dialog/product-form-dialog.component.ts
@@ -38,6 +38,7 @@ export class ProductFormDialogComponent {
     this.form = this.fb.group({
       id:        [data?.id ?? null],
       documentId: [data?.documentId],
+      inventoryId: [data?.inventoryId ?? null],
       sku:       [data?.sku ?? '', [Validators.required, Validators.maxLength(32)]],
       nombre:    [data?.nombre ?? '', [Validators.required, Validators.maxLength(120)]],
       categoria: [data?.categoria ?? null],
@@ -47,7 +48,9 @@ export class ProductFormDialogComponent {
       imagenUrl: [data?.imagenUrl ?? null], // solo UI
       stock:     [data?.stock ?? 0, [Validators.min(0)]],
       minimo:    [data?.minimo ?? 0],       // solo UI por ahora
-      estado:    [data?.estado ?? 'activo'] // solo UI por ahora
+      estado:    [data?.estado ?? 'activo'], // solo UI por ahora
+      adjustmentAction: ['add'],
+      adjustmentQuantity: [0, [Validators.min(0)]],
     });
   }
 
@@ -83,6 +86,17 @@ export class ProductFormDialogComponent {
             productId,
             quantity,
             vendor: v.proveedor ?? null,
+          });
+        }
+      } else {
+        const inventoryId = v.inventoryId ?? this.data?.inventoryId ?? null;
+        const quantity = Number(v.adjustmentQuantity ?? 0);
+        const action = v.adjustmentAction === 'remove' ? 'remove' : 'add';
+
+        if (inventoryId != null && Number.isFinite(quantity) && quantity > 0) {
+          await this.inv.adjustInventoryRecord(inventoryId, {
+            quantity,
+            action,
           });
         }
       }

--- a/src/app/models/inventory/inventory.models.ts
+++ b/src/app/models/inventory/inventory.models.ts
@@ -77,6 +77,14 @@ export interface Product {
   minimo: number;
   estado: ProductStatus;
   imagenUrl?: string | null; // URL absoluta
+  /** Identificador del registro de inventario asociado (Strapi) */
+  inventoryId?: number | string;
+  /** DocumentId del registro de inventario asociado */
+  inventoryDocumentId?: string | null;
+  /** Estado crudo devuelto por el API de inventario (p. ej. `in_stock`) */
+  stockStatus?: string | null;
+  /** Fecha de última actualización del inventario */
+  lastUpdated?: string | null;
 }
 
 // ============================================================================
@@ -112,7 +120,7 @@ function toNumber(n: number | string | null | undefined, fallback = 0): number {
 /**
  * Determina el estado según stock/mínimo.
  */
-const determineProductStatus = (stock: number, minimo: number): ProductStatus => {
+export const determineProductStatus = (stock: number, minimo: number): ProductStatus => {
   if (stock <= 0) return 'inactivo';
   if (stock <= minimo) return 'bajo-stock';
   return 'activo';
@@ -160,6 +168,10 @@ export function mapApiToProduct(apiProduct: ProductApi): Product {
     minimo,
     estado,
     imagenUrl, // 👈 ahora sí mapeado desde Strapi
+    inventoryId: undefined,
+    inventoryDocumentId: undefined,
+    stockStatus: null,
+    lastUpdated: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- merge Strapi product data with the new bulk inventory endpoint so the grid shows real stock levels and metadata
- extend the inventory product model with inventory identifiers and status helpers for downstream use
- allow setting initial stock when creating a product and automatically register it through the createOne inventory endpoint

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_69018fdd2cf08330bd4b8011c6b27c54